### PR TITLE
Migration fixed - misaligment with dbContext

### DIFF
--- a/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/Booker/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -131,7 +131,7 @@ namespace Booker.Areas.Identity.Pages.Account
                     
                     if (selectedSchool != null)
                     {
-                        user.SchoolId = Input.SchoolId.Value;
+                        user.SchoolId = Input.SchoolId.Value;                       
                         _logger.LogInformation(
                             "User manually assigned to school ID {SchoolId}",
                             Input.SchoolId.Value

--- a/Booker/Migrations/20260214133513_AddSchoolsTable.cs
+++ b/Booker/Migrations/20260214133513_AddSchoolsTable.cs
@@ -11,6 +11,11 @@ namespace Booker.Migrations
         /// <inheritdoc />
         protected override void Up(MigrationBuilder migrationBuilder)
         {
+
+            migrationBuilder.DropColumn(
+             name: "School",
+             table: "AspNetUsers");
+
             migrationBuilder.AddColumn<int>(
                 name: "SchoolId",
                 table: "AspNetUsers",
@@ -56,6 +61,13 @@ namespace Booker.Migrations
         /// <inheritdoc />
         protected override void Down(MigrationBuilder migrationBuilder)
         {
+            migrationBuilder.AddColumn<string>(
+                name: "School",
+                table: "AspNetUsers",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
             migrationBuilder.DropForeignKey(
                 name: "FK_AspNetUsers_Schools_SchoolId",
                 table: "AspNetUsers");


### PR DESCRIPTION
#### PR Classification
Code cleanup and architectural simplification by removing per-school database schema isolation.

#### PR Summary
This pull request removes the SchemaName property and all related schema management logic from the School entity and SchoolService, simplifying school management. The database schema, migrations, and UI are updated to reflect this change.
- School.cs and SchoolService.cs: Removed SchemaName property and all schema creation/validation logic.
- Migration and seed files: Updated School table and seed data to exclude SchemaName and include IsActive, CreatedAt, and DeactivatedAt.
- _SchoolRows.cshtml: Removed display of SchemaName column.
- DataContextModelSnapshot.cs and migration files: Removed all references to SchemaName.
- Register.cshtml.cs: Improved logging for manual school assignment.
