### PR TITLE
feat: redesign landing page with hero, categories, and browse

### DIFF
--- a/Booker/Pages/Add.cshtml.cs
+++ b/Booker/Pages/Add.cshtml.cs
@@ -104,15 +104,26 @@ namespace Booker.Pages
                 Input.Title, Input.Grade, Input.Subject, Input.Level
             );
 
-            var result = await _itemManager.AddItemAsync(new ItemManager.ItemModel(
-                (await _userManager.GetUserAsync(User))!,
-                parameters,
-                Input.Description,
-                Input.State,
-                Input.Price,
-                imageStreams,
-                imageExtensions
-            ));
+            ItemManager.Result result;
+            try
+            {
+                result = await _itemManager.AddItemAsync(new ItemManager.ItemModel(
+                    (await _userManager.GetUserAsync(User))!,
+                    parameters,
+                    Input.Description,
+                    Input.State,
+                    Input.Price,
+                    imageStreams,
+                    imageExtensions
+                ));
+            }
+            catch (PhotoStorageException ex)
+            {
+                ModelState.AddModelError("Input.Images", ex.Message);
+                Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await LoadSelects(string.Empty);
+                return Page();
+            }
 
             return ValidateAndReturn(result.Id, result.Status);
         }

--- a/Booker/Pages/Add.cshtml.cs
+++ b/Booker/Pages/Add.cshtml.cs
@@ -33,7 +33,7 @@ namespace Booker.Pages
                 header[4] == 0x0D && header[5] == 0x0A && header[6] == 0x1A && header[7] == 0x0A)
                 return true;
 
-            return true;
+            return false;
         }
 
 
@@ -70,7 +70,7 @@ namespace Booker.Pages
                 }
 
                 // Optional: check extensions for UX
-                string ext = Path.GetExtension(img.FileName)?.ToLowerInvariant();
+                string? ext = Path.GetExtension(img.FileName)?.ToLowerInvariant();
                 if (string.IsNullOrEmpty(ext))
                 {
                     ModelState.AddModelError("Input.Images",

--- a/Booker/Pages/Browse.cshtml
+++ b/Booker/Pages/Browse.cshtml
@@ -1,0 +1,76 @@
+@page
+@model BrowseModel
+@{
+    ViewData["Title"] = "Przeglądaj ogłoszenia";
+}
+
+<section class="filter">
+    <form novalidate
+          hx-get="/Browse"
+          hx-trigger="submit, input changed delay:500ms, change"
+          hx-target=".grid-gallery"
+          hx-push-url="true">
+        <input type="search" name="search" asp-for="Input.Search" placeholder="Wyszukaj..." data-val="false" hx-on:focus="this.nextElementSibling.style.display = 'block';" hx-on:keydown="this.nextElementSibling.style.display = 'none';" />
+        <small style="display: none;">Szukasz książki do przedmiotu zawodowego lub innej rzadko występującej? Wpisz "inna".</small>
+
+        <details id="filterDetails">
+            <summary id="filterSummary">
+                <svg icon="adjustments-horizontal" aria-hidden="true" style="vertical-align: -0.15em;"></svg>
+                Filtry
+            </summary>
+
+            <div class="grid">
+                <select name="grade" asp-for="Input.Grade" asp-items="Model?.Grades" data-val="false">
+                    <option value="">Wszystkie klasy</option>
+                </select>
+
+                <select name="subject" asp-for="Input.Subject" asp-items="Model?.Subjects" data-val="false">
+                    <option value="">Wszystkie przedmioty</option>
+                </select>
+
+                <select name="level" asp-for="Input.Level" asp-items="Model?.Levels">
+                    <option value="">Wszystkie poziomy</option>
+                </select>
+
+                <input type="number" name="minPrice" asp-for="Input.MinPrice" placeholder="Cena min." data-val="false" />
+                <input type="number" name="maxPrice" asp-for="Input.MaxPrice" placeholder="Cena max." data-val="false" />
+            </div>
+
+            <button type="reset" class="secondary" hx-on:click="this.form.reset(); this.form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));" style="width:100%; margin-top:0.5rem;">Wyczyść filtry</button>
+            <button type="button" id="mobileFilterSubmit" style="width:100%; margin-top:0.5rem;">Zatwierdź filtry</button>
+        </details>
+    </form>
+</section>
+
+<section class="grid-gallery">
+    <vc:item-gallery item-ids="@Model.ItemIds" parameters="@Model.Params" />
+</section>
+
+<section>
+    <div aria-busy="true" class="htmx-indicator" id="ind"></div>
+</section>
+
+<script>
+    function setFilter(name, value, enable) {
+        const elem = document.querySelector(`[name="${name}"]`);
+        if (elem) {
+            elem.value = enable ? value : "";
+            elem.form.requestSubmit();
+        }
+    }
+
+    htmx.onLoad(function(content) {
+        content.querySelectorAll('button.subject, button.grade, button.level').forEach(button => {
+            button.addEventListener('click', function() {
+                const name = this.classList.contains('subject') ? 'subject' : this.classList.contains('grade') ? 'grade' : 'level';
+                const value = name === 'grade' ? this.textContent.trim().slice(6,7) : this.textContent.trim();
+                this.classList.toggle('outline');
+                setFilter(name, value, !this.classList.contains('outline'));
+            });
+        });
+    });
+
+    document.getElementById('mobileFilterSubmit').addEventListener('click', function() {
+        document.getElementById('filterDetails').removeAttribute("open");
+    });
+</script>

--- a/Booker/Pages/Browse.cshtml
+++ b/Booker/Pages/Browse.cshtml
@@ -50,27 +50,6 @@
     <div aria-busy="true" class="htmx-indicator" id="ind"></div>
 </section>
 
-<script>
-    function setFilter(name, value, enable) {
-        const elem = document.querySelector(`[name="${name}"]`);
-        if (elem) {
-            elem.value = enable ? value : "";
-            elem.form.requestSubmit();
-        }
-    }
-
-    htmx.onLoad(function(content) {
-        content.querySelectorAll('button.subject, button.grade, button.level').forEach(button => {
-            button.addEventListener('click', function() {
-                const name = this.classList.contains('subject') ? 'subject' : this.classList.contains('grade') ? 'grade' : 'level';
-                const value = name === 'grade' ? this.textContent.trim().slice(6,7) : this.textContent.trim();
-                this.classList.toggle('outline');
-                setFilter(name, value, !this.classList.contains('outline'));
-            });
-        });
-    });
-
-    document.getElementById('mobileFilterSubmit').addEventListener('click', function() {
-        document.getElementById('filterDetails').removeAttribute("open");
-    });
-</script>
+@section Scripts {
+    <script src="~/js/browse.js" asp-append-version="true"></script>
+}

--- a/Booker/Pages/Browse.cshtml.cs
+++ b/Booker/Pages/Browse.cshtml.cs
@@ -10,7 +10,6 @@ namespace Booker.Pages
 {
     public class BrowseModel : PageModel
     {
-        private readonly ILogger<BrowseModel> _logger;
         private readonly ItemManager _itemManager;
         private readonly StaticDataManager _staticDataManager;
         private readonly UserManager<User> _userManager;
@@ -22,13 +21,11 @@ namespace Booker.Pages
         public List<SelectListItem>? Levels { get; set; }
 
         public BrowseModel(
-            ILogger<BrowseModel> logger,
             ItemManager itemManager,
             StaticDataManager staticDataManager,
             UserManager<User> userManager
             )
         {
-            _logger = logger;
             _itemManager = itemManager;
             _staticDataManager = staticDataManager;
             _userManager = userManager;

--- a/Booker/Pages/Browse.cshtml.cs
+++ b/Booker/Pages/Browse.cshtml.cs
@@ -1,0 +1,112 @@
+using Booker.Data;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.AspNetCore.Mvc.Rendering;
+using Booker.Services;
+using Microsoft.AspNetCore.Identity;
+
+namespace Booker.Pages
+{
+    public class BrowseModel : PageModel
+    {
+        private readonly ILogger<BrowseModel> _logger;
+        private readonly ItemManager _itemManager;
+        private readonly StaticDataManager _staticDataManager;
+        private readonly UserManager<User> _userManager;
+
+        public List<int> ItemIds { get; set; } = null!;
+        public StaticDataManager.Parameters Params { get; set; } = null!;
+        public List<SelectListItem>? Grades { get; set; }
+        public List<SelectListItem>? Subjects { get; set; }
+        public List<SelectListItem>? Levels { get; set; }
+
+        public BrowseModel(
+            ILogger<BrowseModel> logger,
+            ItemManager itemManager,
+            StaticDataManager staticDataManager,
+            UserManager<User> userManager
+            )
+        {
+            _logger = logger;
+            _itemManager = itemManager;
+            _staticDataManager = staticDataManager;
+            _userManager = userManager;
+        }
+
+        [FromQuery]
+        public InputModel? Input { get; set; }
+        public class InputModel
+        {
+            public string? Search { get; set; }
+            public string? Grade { get; set; }
+            public string? Subject { get; set; }
+            public decimal? MinPrice { get; set; }
+            public decimal? MaxPrice { get; set; }
+            public string? Level { get; set; }
+        }
+
+        public async Task<IActionResult> OnGetAsync(int pageNumber)
+        {
+            await LoadSelects();
+
+            Params = await _staticDataManager.ConvertParametersAsync(
+                null,
+                Input?.Grade,
+                Input?.Subject,
+                Input?.Level
+            );
+
+            var params2 = new ItemManager.Parameters(
+                Input?.Search,
+                Params.Grades,
+                Params.Subject,
+                Params.Level,
+                Input?.MinPrice,
+                Input?.MaxPrice
+            );
+
+            var currentUser = User.Identity?.IsAuthenticated == true
+                ? await _userManager.GetUserAsync(User)
+                : null;
+
+            ItemIds = await _itemManager.GetItemIdsByParamsAsync(params2, currentUser).ToListAsync();
+
+            if (Request.Headers.ContainsKey("HX-Request"))
+            {
+                return ViewComponent("ItemGallery", new
+                {
+                    itemIds = ItemIds,
+                    parameters = Params,
+                    pageNumber = pageNumber
+                });
+            }
+            return Page();
+        }
+
+        private async Task LoadSelects()
+        {
+            var _grades = await _staticDataManager.GetGradesAsync();
+            var _subjects = await _staticDataManager.GetSubjectsAsync();
+            var _levels = await _staticDataManager.GetLevelsAsync();
+
+            Grades = _grades?.Select(g => new SelectListItem
+            {
+                Value = g.GradeNumber,
+                Text = $"Klasa {g.GradeNumber}."
+            }).ToList();
+
+            Subjects = _subjects?.Select(s => new SelectListItem
+            {
+                Value = s.Name,
+                Text = s.Name
+            }).ToList();
+
+            Levels = _levels?.Select(l => new SelectListItem
+            {
+                Value = l.Name,
+                Text = l.Name
+            }).ToList();
+        }
+    }
+}

--- a/Booker/Pages/Browse.cshtml.cs
+++ b/Booker/Pages/Browse.cshtml.cs
@@ -14,8 +14,9 @@ namespace Booker.Pages
         private readonly StaticDataManager _staticDataManager;
         private readonly UserManager<User> _userManager;
 
-        public List<int> ItemIds { get; set; } = null!;
-        public StaticDataManager.Parameters Params { get; set; } = null!;
+        public List<int> ItemIds { get; set; } = new();
+        public StaticDataManager.Parameters Params { get; set; } =
+            new(null, new List<Grade>(), null, null);
         public List<SelectListItem>? Grades { get; set; }
         public List<SelectListItem>? Subjects { get; set; }
         public List<SelectListItem>? Levels { get; set; }

--- a/Booker/Pages/Edit.cshtml.cs
+++ b/Booker/Pages/Edit.cshtml.cs
@@ -121,7 +121,7 @@ namespace Booker.Pages
             }
 
             await _itemManager.DeleteItemAsync(itemId);
-            return RedirectToPage("/Index");
+            return RedirectToPage("/Browse");
         }
     }
 }

--- a/Booker/Pages/Edit.cshtml.cs
+++ b/Booker/Pages/Edit.cshtml.cs
@@ -94,16 +94,27 @@ namespace Booker.Pages
             var imageStreams = Input.Images?.Select(f => f.OpenReadStream()).ToList();
             var imageExtensions = Input.Images?.Select(f => Path.GetExtension(f.FileName)).ToList();
 
-            var result = await _itemManager.UpdateItemAsync(ItemToEdit, new ItemManager.ItemModel(
-                ItemToEdit.User,
-                parameters,
-                Input.Description,
-                Input.State,
-                Input.Price,
-                imageStreams,
-                imageExtensions,
-                ItemToEdit.Photo
-            ));
+            ItemManager.Status result;
+            try
+            {
+                result = await _itemManager.UpdateItemAsync(ItemToEdit, new ItemManager.ItemModel(
+                    ItemToEdit.User,
+                    parameters,
+                    Input.Description,
+                    Input.State,
+                    Input.Price,
+                    imageStreams,
+                    imageExtensions,
+                    ItemToEdit.Photo
+                ));
+            }
+            catch (PhotoStorageException ex)
+            {
+                ModelState.AddModelError("Input.Images", ex.Message);
+                Response.StatusCode = StatusCodes.Status503ServiceUnavailable;
+                await LoadSelects(string.Empty);
+                return Page();
+            }
 
             return ValidateAndReturn(ItemToEdit.Id, result);
         }

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -64,14 +64,14 @@
 
 <section class="landing-section" aria-label="Popularne przedmioty">
     <h2 style="text-wrap: balance;">Popularne przedmioty</h2>
-    <ul class="category-grid">
+    <ul class="category-badges">
         @foreach (var subject in popularSubjects)
         {
-            var name = string.IsNullOrWhiteSpace(subject.Name) ? "Nieznany przedmiot" : subject.Name;
+            if (string.IsNullOrWhiteSpace(subject.Name)) continue;
             <li class="category-tile" style="--i: @(popularSubjects.ToList().IndexOf(subject));">
                 <a asp-page="/Browse" asp-route-subject="@subject.Name" role="button" class="outline">
                     <svg icon="book" aria-hidden="true"></svg>
-                    <span>@name</span>
+                    <span>@subject.Name</span>
                 </a>
             </li>
         }
@@ -91,7 +91,7 @@
 {
     <section class="landing-section" aria-label="Ostatnio dodane">
         <h2 style="text-wrap: balance;">Ostatnio dodane</h2>
-        <section class="grid-gallery">
+        <section class="grid-gallery grid-gallery-single-row">
             <vc:item-gallery item-ids="@Model.RecentItemIds" parameters="@emptyParams" />
         </section>
     </section>

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -29,28 +29,34 @@
     @if (Model.HeroItems.Count > 0)
     {
         <div class="hero-preview" aria-hidden="true">
-            <div class="hero-carousel">
-                <ul class="hero-carousel-track">
-                    @foreach (var item in Model.HeroItems)
+            <div class="hero-wall">
+                <div class="hero-wall-rotated">
+                    @for (var row = 0; row < 3; row++)
                     {
-                        <li class="hero-book-card">
-                            <div class="hero-book-cover">
-                                @if (!string.IsNullOrEmpty(item.Photo))
-                                {
-                                    <img src="@item.Photo" alt="" />
-                                }
-                                else
-                                {
-                                    <svg icon="book" variant="solid" aria-hidden="true" style="width: 3rem; height: auto; opacity: 0.4;"></svg>
-                                }
-                            </div>
-                            <div class="hero-book-info">
-                                <span class="hero-book-title">@item.Title</span>
-                                <span class="hero-book-price">@item.Price</span>
-                            </div>
-                        </li>
+                        var rowItems = Model.HeroItems.Skip(row * 3).Concat(Model.HeroItems.Take(row * 3));
+                        <div class="hero-wall-row" style="--row: @row;">
+                            @foreach (var item in rowItems.Concat(rowItems))
+                            {
+                                <div class="hero-book-tile">
+                                    <div class="hero-book-cover">
+                                        @if (!string.IsNullOrEmpty(item.Photo))
+                                        {
+                                            <img src="@item.Photo" alt="" />
+                                        }
+                                        else
+                                        {
+                                            <svg icon="book" aria-hidden="true" style="width: 2rem; height: auto; opacity: 0.3;"></svg>
+                                        }
+                                    </div>
+                                    <div class="hero-book-info">
+                                        <span class="hero-book-title">@item.Title</span>
+                                        <span class="hero-book-price">@item.Price</span>
+                                    </div>
+                                </div>
+                            }
+                        </div>
                     }
-                </ul>
+                </div>
             </div>
         </div>
     }

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -26,10 +26,32 @@
         </div>
     </div>
 
-    @if (Model.RecentItemIds.Count > 0)
+    @if (Model.HeroItems.Count > 0)
     {
         <div class="hero-preview" aria-hidden="true">
-            <vc:item-gallery item-ids="@Model.RecentItemIds.Take(1)" parameters="@emptyParams" />
+            <div class="hero-carousel">
+                <ul class="hero-carousel-track">
+                    @foreach (var item in Model.HeroItems)
+                    {
+                        <li class="hero-book-card">
+                            <div class="hero-book-cover">
+                                @if (!string.IsNullOrEmpty(item.Photo))
+                                {
+                                    <img src="@item.Photo" alt="" />
+                                }
+                                else
+                                {
+                                    <svg icon="book" variant="solid" aria-hidden="true" style="width: 3rem; height: auto; opacity: 0.4;"></svg>
+                                }
+                            </div>
+                            <div class="hero-book-info">
+                                <span class="hero-book-title">@item.Title</span>
+                                <span class="hero-book-price">@item.Price</span>
+                            </div>
+                        </li>
+                    }
+                </ul>
+            </div>
         </div>
     }
 </section>

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -2,6 +2,7 @@
 @model IndexModel
 @{
     ViewData["Title"] = "TextBooker";
+    ViewData["MainClass"] = "landing-page";
     var popularSubjects = Model.Subjects.Where(s => !string.IsNullOrWhiteSpace(s.Name) && !s.Name.Equals("Brak", StringComparison.OrdinalIgnoreCase)).ToList();
     var hasMoreSubjects = popularSubjects.Count > 6;
     const int visibleSubjectCount = 6;

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -2,7 +2,7 @@
 @model IndexModel
 @{
     ViewData["Title"] = "TextBooker";
-    var popularSubjects = Model.Subjects.Where(s => !string.IsNullOrWhiteSpace(s.Name)).ToList();
+    var popularSubjects = Model.Subjects.Where(s => !string.IsNullOrWhiteSpace(s.Name) && !s.Name.Equals("Brak", StringComparison.OrdinalIgnoreCase)).ToList();
     var hasMoreSubjects = popularSubjects.Count > 6;
     var emptyParams = new Booker.Services.StaticDataManager.Parameters(null, new List<Booker.Data.Grade>(), null, null);
 }
@@ -31,7 +31,7 @@
         <div class="hero-preview" aria-hidden="true">
             <div class="hero-wall">
                 <div class="hero-wall-rotated">
-                    @for (var row = 0; row < 3; row++)
+                    @for (var row = 0; row < 4; row++)
                     {
                         var rowItems = Model.HeroItems.Skip(row * 3).Concat(Model.HeroItems.Take(row * 3));
                         <div class="hero-wall-row" style="--row: @row;">
@@ -100,12 +100,20 @@
 @section Scripts {
 <script>
 (function () {
-    // ---- Category badges: show only what fits in one line ----
+    // ---- Category badges: show only what fits in one line (desktop only) ----
     var badges = document.querySelector('[data-single-line]');
     if (badges) {
         var items = Array.from(badges.children);
         function fitBadges() {
             items.forEach(function (li) { li.style.display = ''; });
+            // On mobile, show only first 4 badges
+            if (window.innerWidth <= 575) {
+                badges.style.flexWrap = 'wrap';
+                for (var i = 4; i < items.length; i++) {
+                    items[i].style.display = 'none';
+                }
+                return;
+            }
             var containerWidth = badges.clientWidth;
             // Temporarily remove flex-wrap to measure single-line width
             badges.style.flexWrap = 'nowrap';
@@ -119,12 +127,19 @@
         window.addEventListener('resize', fitBadges);
     }
 
-    // ---- Recent items: show only what fits in one row ----
+    // ---- Recent items: show only what fits in one row (desktop only) ----
     var gallery = document.querySelector('[data-single-row]');
     if (gallery) {
         var tiles = Array.from(gallery.children);
         function fitRow() {
             tiles.forEach(function (t) { t.style.display = ''; });
+            // On mobile, show only first 4 items
+            if (window.innerWidth <= 575) {
+                for (var i = 4; i < tiles.length; i++) {
+                    tiles[i].style.display = 'none';
+                }
+                return;
+            }
             var containerWidth = gallery.clientWidth;
             var gap = parseFloat(getComputedStyle(gallery).gap) || 0;
             var totalWidth = 0;

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -103,9 +103,9 @@
 {
     <section class="landing-section" aria-label="Ostatnio dodane">
         <h2 style="text-wrap: balance;">Ostatnio dodane</h2>
-        <section class="grid-gallery grid-gallery-single-row" data-single-row>
+        <div class="grid-gallery grid-gallery-single-row" data-single-row>
             <vc:item-gallery item-ids="@Model.RecentItemIds" parameters="@emptyParams" link-filters="true" />
-        </section>
+        </div>
     </section>
 }
 

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -1,76 +1,70 @@
-﻿@page
+@page
 @model IndexModel
 @{
     ViewData["Title"] = "TextBooker";
+    var popularSubjects = Model.Subjects.Take(8);
+    var hasMoreSubjects = Model.Subjects.Count > 8;
+    var emptyParams = new Booker.Services.StaticDataManager.Parameters(null, new List<Booker.Data.Grade>(), null, null);
 }
 
-<section class="filter">
-    <form novalidate
-          hx-get="/"
-          hx-trigger="submit, input changed delay:500ms, change"
-          hx-target=".grid-gallery"
-          hx-push-url="true">
-        <input type="search" name="search" asp-for="Input.Search" placeholder="Wyszukaj..." data-val="false" hx-on:focus="this.nextElementSibling.style.display = 'block';" hx-on:keydown="this.nextElementSibling.style.display = 'none';" />
-        <small style="display: none;">Szukasz książki do przedmiotu zawodowego lub innej rzadko występującej? Wpisz "inna".</small>
+<section class="landing-hero">
+    <div class="hero-content">
+        <h1 style="text-wrap: balance;">Kupuj i sprzedawaj<br />podręczniki na Śląsku.</h1>
+        <p style="color: var(--pico-muted-color); max-width: 42ch; text-wrap: pretty;">
+            Znajdź tanie książki od uczniów z Twojej okolicy. Wystaw swoje i odzyskaj gotówkę w kilku prostych krokach.
+        </p>
+        <div class="hero-actions">
+            @if (User.Identity?.IsAuthenticated == true)
+            {
+                <a asp-page="/Add" role="button">Dodaj ogłoszenie</a>
+            }
+            else
+            {
+                <a asp-area="Identity" asp-page="/Account/Register" role="button">Załóż konto</a>
+            }
+            <a asp-page="/Browse" role="button" class="outline">Przeglądaj oferty</a>
+        </div>
+    </div>
 
-        <details id="filterDetails">
-            <summary id="filterSummary">
-                <svg icon="adjustments-horizontal" aria-hidden="true" style="vertical-align: -0.15em;"></svg>
-                Filtry
-            </summary>
-
-            <div class="grid">
-                <select name="grade" asp-for="Input.Grade" asp-items="Model?.Grades" data-val="false">
-                    <option value="">Wszystkie klasy</option>
-                </select>
-
-                <select name="subject" asp-for="Input.Subject" asp-items="Model?.Subjects" data-val="false">
-                    <option value="">Wszystkie przedmioty</option>
-                </select>
-
-                <select name="level" asp-for="Input.Level" asp-items="Model?.Levels">
-                    <option value="">Wszystkie poziomy</option>
-                </select>
-
-                <input type="number" name="minPrice" asp-for="Input.MinPrice" placeholder="Cena min." data-val="false" />
-                <input type="number" name="maxPrice" asp-for="Input.MaxPrice" placeholder="Cena max." data-val="false" />
-            </div>
-
-            <button type="reset" class="secondary" hx-on:click="this.form.reset(); this.form.dispatchEvent(new Event('submit', { bubbles: true, cancelable: true }));" style="width:100%; margin-top:0.5rem;">Wyczyść filtry</button>
-            <button type="button" id="mobileFilterSubmit" style="width:100%; margin-top:0.5rem;">Zatwierdź filtry</button>
-        </details>
-    </form>
-</section>
-
-<section class="grid-gallery">
-    <vc:item-gallery item-ids="@Model.ItemIds" parameters="@Model.Params" />
-</section>
-
-<section>
-    <div aria-busy="true" class="htmx-indicator" id="ind"></div>
-</section>
-
-<script>
-    function setFilter(name, value, enable) {
-        const elem = document.querySelector(`[name="${name}"]`);
-        if (elem) {
-            elem.value = enable ? value : "";
-            elem.form.requestSubmit();
-        }
+    @if (Model.RecentItemIds.Count > 0)
+    {
+        <div class="hero-preview" aria-hidden="true">
+            <vc:item-gallery item-ids="@Model.RecentItemIds.Take(3)" parameters="@emptyParams" />
+        </div>
     }
+</section>
 
-    htmx.onLoad(function(content) {
-        content.querySelectorAll('button.subject, button.grade, button.level').forEach(button => {
-            button.addEventListener('click', function() {
-                const name = this.classList.contains('subject') ? 'subject' : this.classList.contains('grade') ? 'grade' : 'level';
-                const value = name === 'grade' ? this.textContent.trim().slice(6,7) : this.textContent.trim();
-                this.classList.toggle('outline');
-                setFilter(name, value, !this.classList.contains('outline'));
-            });
-        });
-    });
+<section class="landing-section" aria-label="Popularne przedmioty">
+    <h2 style="text-wrap: balance;">Popularne przedmioty</h2>
+    <ul class="category-grid">
+        @foreach (var subject in popularSubjects)
+        {
+            var name = string.IsNullOrWhiteSpace(subject.Name) ? "Nieznany przedmiot" : subject.Name;
+            <li class="category-tile" style="--i: @(popularSubjects.ToList().IndexOf(subject));">
+                <a asp-page="/Browse" asp-route-subject="@subject.Name" role="button" class="outline">
+                    <svg icon="book" aria-hidden="true"></svg>
+                    <span>@name</span>
+                </a>
+            </li>
+        }
+    </ul>
+    @if (hasMoreSubjects)
+    {
+        <div class="see-all-categories">
+            <a asp-page="/Browse">
+                Zobacz wszystkie przedmioty
+                <svg icon="arrow-right" aria-hidden="true" style="width: 1em; vertical-align: -0.15em;"></svg>
+            </a>
+        </div>
+    }
+</section>
 
-    document.getElementById('mobileFilterSubmit').addEventListener('click', function() {
-        document.getElementById('filterDetails').removeAttribute("open");
-    });
-</script>
+@if (Model.RecentItemIds.Count > 0)
+{
+    <section class="landing-section" aria-label="Ostatnio dodane">
+        <h2 style="text-wrap: balance;">Ostatnio dodane</h2>
+        <section class="grid-gallery">
+            <vc:item-gallery item-ids="@Model.RecentItemIds" parameters="@emptyParams" />
+        </section>
+    </section>
+}

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -2,8 +2,8 @@
 @model IndexModel
 @{
     ViewData["Title"] = "TextBooker";
-    var popularSubjects = Model.Subjects.Take(8);
-    var hasMoreSubjects = Model.Subjects.Count > 8;
+    var popularSubjects = Model.Subjects.Where(s => !string.IsNullOrWhiteSpace(s.Name)).Take(6).ToList();
+    var hasMoreSubjects = Model.Subjects.Count(s => !string.IsNullOrWhiteSpace(s.Name)) > 6;
     var emptyParams = new Booker.Services.StaticDataManager.Parameters(null, new List<Booker.Data.Grade>(), null, null);
 }
 
@@ -65,10 +65,10 @@
 <section class="landing-section" aria-label="Popularne przedmioty">
     <h2 style="text-wrap: balance;">Popularne przedmioty</h2>
     <ul class="category-badges">
-        @foreach (var subject in popularSubjects)
+        @for (var i = 0; i < popularSubjects.Count; i++)
         {
-            if (string.IsNullOrWhiteSpace(subject.Name)) continue;
-            <li class="category-tile" style="--i: @(popularSubjects.ToList().IndexOf(subject));">
+            var subject = popularSubjects[i];
+            <li class="category-tile" style="--i: @i;">
                 <a asp-page="/Browse" asp-route-subject="@subject.Name" role="button" class="outline">
                     <svg icon="book" aria-hidden="true"></svg>
                     <span>@subject.Name</span>

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -2,8 +2,8 @@
 @model IndexModel
 @{
     ViewData["Title"] = "TextBooker";
-    var popularSubjects = Model.Subjects.Where(s => !string.IsNullOrWhiteSpace(s.Name)).Take(6).ToList();
-    var hasMoreSubjects = Model.Subjects.Count(s => !string.IsNullOrWhiteSpace(s.Name)) > 6;
+    var popularSubjects = Model.Subjects.Where(s => !string.IsNullOrWhiteSpace(s.Name)).ToList();
+    var hasMoreSubjects = popularSubjects.Count > 6;
     var emptyParams = new Booker.Services.StaticDataManager.Parameters(null, new List<Booker.Data.Grade>(), null, null);
 }
 
@@ -64,7 +64,7 @@
 
 <section class="landing-section" aria-label="Popularne przedmioty">
     <h2 style="text-wrap: balance;">Popularne przedmioty</h2>
-    <ul class="category-badges">
+    <ul class="category-badges" data-single-line>
         @for (var i = 0; i < popularSubjects.Count; i++)
         {
             var subject = popularSubjects[i];
@@ -91,8 +91,56 @@
 {
     <section class="landing-section" aria-label="Ostatnio dodane">
         <h2 style="text-wrap: balance;">Ostatnio dodane</h2>
-        <section class="grid-gallery grid-gallery-single-row">
+        <section class="grid-gallery grid-gallery-single-row" data-single-row>
             <vc:item-gallery item-ids="@Model.RecentItemIds" parameters="@emptyParams" />
         </section>
     </section>
+}
+
+@section Scripts {
+<script>
+(function () {
+    // ---- Category badges: show only what fits in one line ----
+    var badges = document.querySelector('[data-single-line]');
+    if (badges) {
+        var items = Array.from(badges.children);
+        function fitBadges() {
+            items.forEach(function (li) { li.style.display = ''; });
+            var containerWidth = badges.clientWidth;
+            // Temporarily remove flex-wrap to measure single-line width
+            badges.style.flexWrap = 'nowrap';
+            for (var i = items.length - 1; i >= 0; i--) {
+                if (badges.scrollWidth > containerWidth) {
+                    items[i].style.display = 'none';
+                }
+            }
+        }
+        fitBadges();
+        window.addEventListener('resize', fitBadges);
+    }
+
+    // ---- Recent items: show only what fits in one row ----
+    var gallery = document.querySelector('[data-single-row]');
+    if (gallery) {
+        var tiles = Array.from(gallery.children);
+        function fitRow() {
+            tiles.forEach(function (t) { t.style.display = ''; });
+            var containerWidth = gallery.clientWidth;
+            var gap = parseFloat(getComputedStyle(gallery).gap) || 0;
+            var totalWidth = 0;
+            for (var i = 0; i < tiles.length; i++) {
+                totalWidth += tiles[i].getBoundingClientRect().width;
+                if (i > 0) totalWidth += gap;
+                if (totalWidth > containerWidth + 1) {
+                    tiles[i].style.display = 'none';
+                }
+            }
+        }
+        // Run after images start loading to get accurate measurements
+        requestAnimationFrame(fitRow);
+        window.addEventListener('resize', fitRow);
+        window.addEventListener('load', fitRow);
+    }
+})();
+</script>
 }

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -29,7 +29,7 @@
     @if (Model.RecentItemIds.Count > 0)
     {
         <div class="hero-preview" aria-hidden="true">
-            <vc:item-gallery item-ids="@Model.RecentItemIds.Take(3)" parameters="@emptyParams" />
+            <vc:item-gallery item-ids="@Model.RecentItemIds.Take(1)" parameters="@emptyParams" />
         </div>
     }
 </section>

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -4,6 +4,10 @@
     ViewData["Title"] = "TextBooker";
     var popularSubjects = Model.Subjects.Where(s => !string.IsNullOrWhiteSpace(s.Name) && !s.Name.Equals("Brak", StringComparison.OrdinalIgnoreCase)).ToList();
     var hasMoreSubjects = popularSubjects.Count > 6;
+    const int visibleSubjectCount = 6;
+    const int heroItemsPerRow = 4;
+    const int heroRowCount = 3;
+    const int heroSequenceCopies = 4;
     var emptyParams = new Booker.Services.StaticDataManager.Parameters(null, new List<Booker.Data.Grade>(), null, null);
 }
 
@@ -31,17 +35,17 @@
         <div class="hero-preview" aria-hidden="true">
             <div class="hero-wall">
                 <div class="hero-wall-rotated">
-                    @for (var row = 0; row < 3; row++)
+                    @for (var row = 0; row < heroRowCount; row++)
                     {
                         var rowItems = Model.HeroItems
-                            .Skip(row * 4)
-                            .Concat(Model.HeroItems.Take(row * 4))
-                            .Take(4)
+                            .Skip(row * heroItemsPerRow)
+                            .Concat(Model.HeroItems.Take(row * heroItemsPerRow))
+                            .Take(heroItemsPerRow)
                             .ToList();
 
                         <div class="hero-wall-row">
                             <div class="hero-wall-track">
-                                @for (var copy = 0; copy < 4; copy++)
+                                @for (var copy = 0; copy < heroSequenceCopies; copy++)
                                 {
                                     <div class="hero-wall-sequence">
                                         @foreach (var item in rowItems)
@@ -76,8 +80,8 @@
 
 <section class="landing-section" aria-label="Popularne przedmioty">
     <h2 style="text-wrap: balance;">Popularne przedmioty</h2>
-    <ul class="category-badges" data-single-line>
-        @for (var i = 0; i < popularSubjects.Count; i++)
+    <ul class="category-badges">
+        @for (var i = 0; i < Math.Min(popularSubjects.Count, visibleSubjectCount); i++)
         {
             var subject = popularSubjects[i];
             <li class="category-tile" style="--i: @i;">
@@ -103,71 +107,8 @@
 {
     <section class="landing-section" aria-label="Ostatnio dodane">
         <h2 style="text-wrap: balance;">Ostatnio dodane</h2>
-        <div class="grid-gallery grid-gallery-single-row" data-single-row>
+        <div class="grid-gallery grid-gallery-single-row">
             <vc:item-gallery item-ids="@Model.RecentItemIds" parameters="@emptyParams" link-filters="true" />
         </div>
     </section>
-}
-
-@section Scripts {
-<script>
-(function () {
-    // ---- Category badges: show only what fits in one line (desktop only) ----
-    var badges = document.querySelector('[data-single-line]');
-    if (badges) {
-        var items = Array.from(badges.children);
-        function fitBadges() {
-            items.forEach(function (li) { li.style.display = ''; });
-            // On mobile, show only first 4 badges
-            if (window.innerWidth <= 575) {
-                badges.style.flexWrap = 'wrap';
-                for (var i = 4; i < items.length; i++) {
-                    items[i].style.display = 'none';
-                }
-                return;
-            }
-            var containerWidth = badges.clientWidth;
-            // Temporarily remove flex-wrap to measure single-line width
-            badges.style.flexWrap = 'nowrap';
-            for (var i = items.length - 1; i >= 0; i--) {
-                if (badges.scrollWidth > containerWidth) {
-                    items[i].style.display = 'none';
-                }
-            }
-        }
-        fitBadges();
-        window.addEventListener('resize', fitBadges);
-    }
-
-    // ---- Recent items: show only what fits in one row (desktop only) ----
-    var gallery = document.querySelector('[data-single-row]');
-    if (gallery) {
-        var tiles = Array.from(gallery.children);
-        function fitRow() {
-            tiles.forEach(function (t) { t.style.display = ''; });
-            // On mobile, show only first 4 items
-            if (window.innerWidth <= 575) {
-                for (var i = 4; i < tiles.length; i++) {
-                    tiles[i].style.display = 'none';
-                }
-                return;
-            }
-            var containerWidth = gallery.clientWidth;
-            var gap = parseFloat(getComputedStyle(gallery).gap) || 0;
-            var totalWidth = 0;
-            for (var i = 0; i < tiles.length; i++) {
-                totalWidth += tiles[i].getBoundingClientRect().width;
-                if (i > 0) totalWidth += gap;
-                if (totalWidth > containerWidth + 1) {
-                    tiles[i].style.display = 'none';
-                }
-            }
-        }
-        // Run after images start loading to get accurate measurements
-        requestAnimationFrame(fitRow);
-        window.addEventListener('resize', fitRow);
-        window.addEventListener('load', fitRow);
-    }
-})();
-</script>
 }

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -104,7 +104,7 @@
     <section class="landing-section" aria-label="Ostatnio dodane">
         <h2 style="text-wrap: balance;">Ostatnio dodane</h2>
         <section class="grid-gallery grid-gallery-single-row" data-single-row>
-            <vc:item-gallery item-ids="@Model.RecentItemIds" parameters="@emptyParams" />
+            <vc:item-gallery item-ids="@Model.RecentItemIds" parameters="@emptyParams" link-filters="true" />
         </section>
     </section>
 }

--- a/Booker/Pages/Index.cshtml
+++ b/Booker/Pages/Index.cshtml
@@ -31,29 +31,41 @@
         <div class="hero-preview" aria-hidden="true">
             <div class="hero-wall">
                 <div class="hero-wall-rotated">
-                    @for (var row = 0; row < 4; row++)
+                    @for (var row = 0; row < 3; row++)
                     {
-                        var rowItems = Model.HeroItems.Skip(row * 3).Concat(Model.HeroItems.Take(row * 3));
-                        <div class="hero-wall-row" style="--row: @row;">
-                            @foreach (var item in rowItems.Concat(rowItems))
-                            {
-                                <div class="hero-book-tile">
-                                    <div class="hero-book-cover">
-                                        @if (!string.IsNullOrEmpty(item.Photo))
+                        var rowItems = Model.HeroItems
+                            .Skip(row * 4)
+                            .Concat(Model.HeroItems.Take(row * 4))
+                            .Take(4)
+                            .ToList();
+
+                        <div class="hero-wall-row">
+                            <div class="hero-wall-track">
+                                @for (var copy = 0; copy < 4; copy++)
+                                {
+                                    <div class="hero-wall-sequence">
+                                        @foreach (var item in rowItems)
                                         {
-                                            <img src="@item.Photo" alt="" />
-                                        }
-                                        else
-                                        {
-                                            <svg icon="book" aria-hidden="true" style="width: 2rem; height: auto; opacity: 0.3;"></svg>
+                                            <div class="hero-book-tile">
+                                                <div class="hero-book-cover">
+                                                    @if (!string.IsNullOrEmpty(item.Photo))
+                                                    {
+                                                        <img src="@item.Photo" alt="" />
+                                                    }
+                                                    else
+                                                    {
+                                                        <svg icon="book" aria-hidden="true" style="width: 2rem; height: auto; opacity: 0.3;"></svg>
+                                                    }
+                                                </div>
+                                                <div class="hero-book-info">
+                                                    <span class="hero-book-title">@item.Title</span>
+                                                    <span class="hero-book-price">@item.Price</span>
+                                                </div>
+                                            </div>
                                         }
                                     </div>
-                                    <div class="hero-book-info">
-                                        <span class="hero-book-title">@item.Title</span>
-                                        <span class="hero-book-price">@item.Price</span>
-                                    </div>
-                                </div>
-                            }
+                                }
+                            </div>
                         </div>
                     }
                 </div>

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -12,20 +12,26 @@ namespace Booker.Pages
         private readonly StaticDataManager _staticDataManager;
         private readonly ItemManager _itemManager;
         private readonly UserManager<User> _userManager;
+        private readonly PhotosManager _photosManager;
 
         public List<Subject> Subjects { get; set; } = null!;
         public List<int> RecentItemIds { get; set; } = null!;
+        public List<HeroItem> HeroItems { get; set; } = null!;
 
         public IndexModel(
             StaticDataManager staticDataManager,
             ItemManager itemManager,
-            UserManager<User> userManager
+            UserManager<User> userManager,
+            PhotosManager photosManager
         )
         {
             _staticDataManager = staticDataManager;
             _itemManager = itemManager;
             _userManager = userManager;
+            _photosManager = photosManager;
         }
+
+        public record HeroItem(string Title, string Price, string Photo);
 
         public async Task<IActionResult> OnGetAsync()
         {
@@ -47,6 +53,19 @@ namespace Booker.Pages
             RecentItemIds = await _itemManager
                 .GetItemIdsByParamsAsync(params2, currentUser)
                 .Take(8)
+                .ToListAsync();
+
+            HeroItems = await _itemManager
+                .GetItemsByIdsAsync(RecentItemIds, currentUser)
+                .Where(i => i.IsVisible)
+                .Take(5)
+                .Select(i => new HeroItem(
+                    i.Book.Title,
+                    i.Price.ToString("F2") + " zł",
+                    i.Photo != null && i.Photo.Length > 0
+                        ? _photosManager.GetPhotoUrl(i.Photo.Split(';')[0].Trim())
+                        : ""
+                ))
                 .ToListAsync();
 
             return Page();

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -52,7 +52,7 @@ namespace Booker.Pages
 
             RecentItemIds = await _itemManager
                 .GetItemIdsByParamsAsync(params2, currentUser)
-                .Take(4)
+                .Take(8)
                 .ToListAsync();
 
             var heroIds = await _itemManager

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -1,8 +1,7 @@
-﻿using Booker.Data;
+using Booker.Data;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using Microsoft.AspNetCore.Mvc.Rendering;
 using Booker.Services;
 using Microsoft.AspNetCore.Identity;
 
@@ -10,103 +9,47 @@ namespace Booker.Pages
 {
     public class IndexModel : PageModel
     {
-        private readonly ILogger<IndexModel> _logger;
-        private readonly ItemManager _itemManager;
         private readonly StaticDataManager _staticDataManager;
+        private readonly ItemManager _itemManager;
         private readonly UserManager<User> _userManager;
 
-        public List<int> ItemIds { get; set; } = null!;
-        public StaticDataManager.Parameters Params { get; set; } = null!;
-        public List<SelectListItem>? Grades { get; set; }
-        public List<SelectListItem>? Subjects { get; set; }
-        public List<SelectListItem>? Levels {get; set; }
+        public List<Subject> Subjects { get; set; } = null!;
+        public List<int> RecentItemIds { get; set; } = null!;
 
         public IndexModel(
-            ILogger<IndexModel> logger,
-            ItemManager itemManager,
             StaticDataManager staticDataManager,
+            ItemManager itemManager,
             UserManager<User> userManager
-            )
+        )
         {
-            _logger = logger;
-            _itemManager = itemManager;
             _staticDataManager = staticDataManager;
+            _itemManager = itemManager;
             _userManager = userManager;
         }
 
-        [FromQuery]
-        public InputModel? Input { get; set; }
-        public class InputModel
+        public async Task<IActionResult> OnGetAsync()
         {
-            public string? Search { get; set; }
-            public string? Grade { get; set; }
-            public string? Subject { get; set; }
-            public decimal? MinPrice { get; set; }
-            public decimal? MaxPrice { get; set; }
-            public string? Level { get; set; }
-        }
+            Subjects = await _staticDataManager.GetSubjectsAsync();
 
-        public async Task<IActionResult> OnGetAsync(int pageNumber)
-        {
-            await LoadSelects();
-
-            Params = await _staticDataManager.ConvertParametersAsync(
-                null,
-                Input?.Grade,
-                Input?.Subject,
-                Input?.Level
-            );
+            var currentUser = User.Identity?.IsAuthenticated == true
+                ? await _userManager.GetUserAsync(User)
+                : null;
 
             var params2 = new ItemManager.Parameters(
-                Input?.Search,
-                Params.Grades,
-                Params.Subject,
-                Params.Level,
-                Input?.MinPrice,
-                Input?.MaxPrice
+                Search: null,
+                Grades: new(),
+                Subject: null,
+                Level: null,
+                MinPrice: null,
+                MaxPrice: null
             );
 
-            var currentUser = User.Identity?.IsAuthenticated == true 
-                ? await _userManager.GetUserAsync(User) 
-                : null;
-                
-            ItemIds = await _itemManager.GetItemIdsByParamsAsync(params2, currentUser).ToListAsync();
+            RecentItemIds = await _itemManager
+                .GetItemIdsByParamsAsync(params2, currentUser)
+                .Take(8)
+                .ToListAsync();
 
-            if (Request.Headers.ContainsKey("HX-Request"))
-            {
-                return ViewComponent("ItemGallery", new
-                {
-                    itemIds = ItemIds,
-                    parameters = Params,
-                    pageNumber = pageNumber
-                });
-            }
             return Page();
-        }
-
-        private async Task LoadSelects()
-        {
-            var _grades = await _staticDataManager.GetGradesAsync();
-            var _subjects = await _staticDataManager.GetSubjectsAsync();
-            var _levels = await _staticDataManager.GetLevelsAsync();
-
-            Grades = _grades?.Select(g => new SelectListItem
-            {
-                Value = g.GradeNumber,
-                Text = $"Klasa {g.GradeNumber}."
-            }).ToList();
-
-            Subjects = _subjects?.Select(s => new SelectListItem
-            {
-                Value = s.Name,
-                Text = s.Name
-            }).ToList();
-
-            Levels = _levels?.Select(l => new SelectListItem
-            {
-                Value = l.Name,
-                Text = l.Name
-            }).ToList();
         }
     }
 }

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -58,7 +58,7 @@ namespace Booker.Pages
             HeroItems = await _itemManager
                 .GetItemsByIdsAsync(RecentItemIds, currentUser)
                 .Where(i => i.IsVisible)
-                .Take(5)
+                .Take(10)
                 .Select(i => new HeroItem(
                     i.Book.Title,
                     i.Price.ToString("F2") + " zł",

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -52,7 +52,7 @@ namespace Booker.Pages
 
             RecentItemIds = await _itemManager
                 .GetItemIdsByParamsAsync(params2, currentUser)
-                .Take(8)
+                .Take(4)
                 .ToListAsync();
 
             var heroIds = await _itemManager

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -52,13 +52,18 @@ namespace Booker.Pages
 
             RecentItemIds = await _itemManager
                 .GetItemIdsByParamsAsync(params2, currentUser)
-                .Take(8)
+                .Take(4)
+                .ToListAsync();
+
+            var heroIds = await _itemManager
+                .GetItemIdsByParamsAsync(params2, currentUser)
+                .Take(12)
                 .ToListAsync();
 
             HeroItems = await _itemManager
-                .GetItemsByIdsAsync(RecentItemIds, currentUser)
+                .GetItemsByIdsAsync(heroIds, currentUser)
                 .Where(i => i.IsVisible)
-                .Take(10)
+                .Take(12)
                 .Select(i => new HeroItem(
                     i.Book.Title,
                     i.Price.ToString("F2") + " zł",

--- a/Booker/Pages/Index.cshtml.cs
+++ b/Booker/Pages/Index.cshtml.cs
@@ -14,9 +14,9 @@ namespace Booker.Pages
         private readonly UserManager<User> _userManager;
         private readonly PhotosManager _photosManager;
 
-        public List<Subject> Subjects { get; set; } = null!;
-        public List<int> RecentItemIds { get; set; } = null!;
-        public List<HeroItem> HeroItems { get; set; } = null!;
+        public List<Subject> Subjects { get; set; } = new();
+        public List<int> RecentItemIds { get; set; } = new();
+        public List<HeroItem> HeroItems { get; set; } = new();
 
         public IndexModel(
             StaticDataManager staticDataManager,
@@ -50,18 +50,15 @@ namespace Booker.Pages
                 MaxPrice: null
             );
 
-            RecentItemIds = await _itemManager
-                .GetItemIdsByParamsAsync(params2, currentUser)
-                .Take(8)
-                .ToListAsync();
-
-            var heroIds = await _itemManager
+            var landingItemIds = await _itemManager
                 .GetItemIdsByParamsAsync(params2, currentUser)
                 .Take(12)
                 .ToListAsync();
 
+            RecentItemIds = landingItemIds.Take(8).ToList();
+
             HeroItems = await _itemManager
-                .GetItemsByIdsAsync(heroIds, currentUser)
+                .GetItemsByIdsAsync(landingItemIds, currentUser)
                 .Where(i => i.IsVisible)
                 .Take(12)
                 .Select(i => new HeroItem(

--- a/Booker/Pages/Shared/Components/ItemGallery/Default.cshtml
+++ b/Booker/Pages/Shared/Components/ItemGallery/Default.cshtml
@@ -5,7 +5,8 @@
     @await Html.PartialAsync("_BookTile", new ItemGalleryViewComponent.ItemModel(
                 item.Item,       
                 item.FirstPhoto, 
-                item.Params      
+                item.Params,
+                item.LinkFilters
             ))
 }
 

--- a/Booker/Pages/Shared/Components/ItemGallery/ItemGalleryViewComponent.cs
+++ b/Booker/Pages/Shared/Components/ItemGallery/ItemGalleryViewComponent.cs
@@ -24,7 +24,8 @@ public class ItemGalleryViewComponent : ViewComponent
     public record ItemModel(
         Item Item,
         string FirstPhoto,
-        StaticDataManager.Parameters Params
+        StaticDataManager.Parameters Params,
+        bool LinkFilters
     );
 
     public ItemGalleryViewComponent(ItemManager itemManager, UserManager<User> userManager, PhotosManager photosManager)
@@ -39,7 +40,8 @@ public class ItemGalleryViewComponent : ViewComponent
         StaticDataManager.Parameters parameters,
         int pageNumber = 0,
         int pageSize = PageSize,
-        bool showHidden = false
+        bool showHidden = false,
+        bool linkFilters = false
     )
     {
         if (!itemIds.Any())
@@ -65,7 +67,8 @@ public class ItemGalleryViewComponent : ViewComponent
             FirstPhoto: string.IsNullOrEmpty(item.Photo)
                 ? "/images/default-book.png" // fallback
                 : _photosManager.GetPhotoUrl(item.Photo.Split(';')[0].Trim()),
-            Params: parameters
+            Params: parameters,
+            LinkFilters: linkFilters
         ));
 
         return View(

--- a/Booker/Pages/Shared/_BookTile.cshtml
+++ b/Booker/Pages/Shared/_BookTile.cshtml
@@ -22,7 +22,7 @@
 }
 
 <article class="book-tile @(Model.Item.Reserved ? "reserved" : "")">
-    <img src="@Model.FirstPhoto" alt="@Model.Item.Book.Title" />
+    <img src="@Model.FirstPhoto" alt="@(Model.Item.Reserved ? $"{Model.Item.Book.Title} – zarezerwowane" : Model.Item.Book.Title)" />
     <footer>
         <div class="info">
             <a asp-page="/Book" asp-route-id="@Model.Item.Id">

--- a/Booker/Pages/Shared/_BookTile.cshtml
+++ b/Booker/Pages/Shared/_BookTile.cshtml
@@ -37,23 +37,50 @@
             </p>
         </div>
         <div class="actions">
-            <button class='@(Model.Item.Book.Subject.Id == Model.Params.Subject?.Id ? "" : "outline") subject'>
-                @(string.IsNullOrWhiteSpace(Model.Item.Book.Subject.Name) ? "Nieznany przedmiot" : Model.Item.Book.Subject.Name)
-            </button>
+            @if (Model.LinkFilters)
+            {
+                <a role="button" class="outline" asp-page="/Browse" asp-route-subject="@Model.Item.Book.Subject.Name">
+                    @(string.IsNullOrWhiteSpace(Model.Item.Book.Subject.Name) ? "Nieznany przedmiot" : Model.Item.Book.Subject.Name)
+                </a>
+            }
+            else
+            {
+                <button type="button" class='@(Model.Item.Book.Subject.Id == Model.Params.Subject?.Id ? "" : "outline") subject'>
+                    @(string.IsNullOrWhiteSpace(Model.Item.Book.Subject.Name) ? "Nieznany przedmiot" : Model.Item.Book.Subject.Name)
+                </button>
+            }
             @if (Model.Item.Book.Grades != null)
             {
                 @foreach (var grade in Model.Item.Book.Grades)
                 {
-                    <button class='@(Model.Params.Grades.Contains(grade) ? "" : "outline") grade'>
-                        @DisplayGrade(grade.GradeNumber)
-                    </button>
+                    @if (Model.LinkFilters)
+                    {
+                        <a role="button" class="outline" asp-page="/Browse" asp-route-grade="@grade.GradeNumber">
+                            @DisplayGrade(grade.GradeNumber)
+                        </a>
+                    }
+                    else
+                    {
+                        <button type="button" class='@(Model.Params.Grades.Contains(grade) ? "" : "outline") grade'>
+                            @DisplayGrade(grade.GradeNumber)
+                        </button>
+                    }
                 }
             }
             @if (Model.Item.Book.Level != null)
             {
-                <button class='@(Model.Item.Book.Level == Model.Params.Level ? "" : "outline") level'>
-                    @Model.Item.Book.Level.Name
-                </button>
+                @if (Model.LinkFilters)
+                {
+                    <a role="button" class="outline" asp-page="/Browse" asp-route-level="@Model.Item.Book.Level.Name">
+                        @Model.Item.Book.Level.Name
+                    </a>
+                }
+                else
+                {
+                    <button type="button" class='@(Model.Item.Book.Level == Model.Params.Level ? "" : "outline") level'>
+                        @Model.Item.Book.Level.Name
+                    </button>
+                }
             }
         </div>
         <div class="fav">

--- a/Booker/Pages/Shared/_Layout.cshtml
+++ b/Booker/Pages/Shared/_Layout.cshtml
@@ -82,7 +82,27 @@
         </article>
     </dialog>
 
-    <footer class="container">
+    <footer class="container-fluid" role="contentinfo">
+        <div class="container">
+            <div class="footer-content">
+                <a asp-area="" asp-page="/Index">
+                    <img src="/img/logo-text.svg" alt="TextBooker" style="height: 1.75rem;">
+                </a>
+                <nav aria-label="Stopka">
+                    <ul role="list">
+                        <li><a asp-area="" asp-page="/Privacy">Polityka prywatności</a></li>
+                        <li>
+                            <button class="footer-help-link"
+                                    data-target="modal-example"
+                                    onclick="document.getElementById(this.dataset.target).showModal()">
+                                Centrum pomocy
+                            </button>
+                        </li>
+                        <li><a href="mailto:support@textbooker.pl">Kontakt</a></li>
+                    </ul>
+                </nav>
+            </div>
+        </div>
     </footer>
 
     <script src="~/js/validation/aspnet-validation.min.js" asp-append-version="true"></script>

--- a/Booker/Pages/Shared/_Layout.cshtml
+++ b/Booker/Pages/Shared/_Layout.cshtml
@@ -93,6 +93,7 @@
                         <li><a asp-area="" asp-page="/Privacy">Polityka prywatności</a></li>
                         <li>
                             <button class="footer-help-link"
+                                    type="button"
                                     data-target="modal-example"
                                     onclick="document.getElementById(this.dataset.target).showModal()">
                                 Centrum pomocy

--- a/Booker/Pages/Shared/_Layout.cshtml
+++ b/Booker/Pages/Shared/_Layout.cshtml
@@ -33,7 +33,7 @@
         @await Html.PartialAsync("_LoginPartial")
     </nav>
 
-    <main class="container">
+    <main class="container @(ViewData["MainClass"])">
         @RenderBody()
     </main>
 

--- a/Booker/Pages/Shared/_LoginPartial.cshtml
+++ b/Booker/Pages/Shared/_LoginPartial.cshtml
@@ -42,10 +42,10 @@
 else
 {
     <li>
-        <a id="login" asp-area="Identity" asp-page="/Account/Login" style="color: var(--pico-muted-color); font-size: 0.875rem; align-self: center;">Zaloguj się</a>
+        <a id="login" asp-area="Identity" asp-page="/Account/Login">Zaloguj się</a>
     </li>
     <li>
-        <a id="register" role="button" class="outline" asp-area="Identity" asp-page="/Account/Register" style="margin-bottom: 0; --pico-font-size: 0.75rem; padding-block: 0.35rem; padding-inline: 0.75rem;">Zarejestruj się</a>
+        <a id="register" role="button" asp-area="Identity" asp-page="/Account/Register">Zarejestruj się</a>
     </li>
 }
 </ul>

--- a/Booker/Pages/Shared/_LoginPartial.cshtml
+++ b/Booker/Pages/Shared/_LoginPartial.cshtml
@@ -42,10 +42,10 @@
 else
 {
     <li>
-        <a id="register" asp-area="Identity" asp-page="/Account/Register">Zarejestruj się</a>
+        <a id="login" asp-area="Identity" asp-page="/Account/Login" style="color: var(--pico-muted-color); font-size: 0.875rem; align-self: center;">Zaloguj się</a>
     </li>
     <li>
-        <a id="login" asp-area="Identity" asp-page="/Account/Login">Zaloguj się</a>
+        <a id="register" role="button" class="outline" asp-area="Identity" asp-page="/Account/Register" style="margin-bottom: 0; --pico-font-size: 0.75rem; padding-block: 0.35rem; padding-inline: 0.75rem;">Zarejestruj się</a>
     </li>
 }
 </ul>

--- a/Booker/Services/PhotosManager.cs
+++ b/Booker/Services/PhotosManager.cs
@@ -6,7 +6,7 @@ using System.Net;
 
 namespace Booker.Services;
 
-public class PhotosManager(ILogger<PhotosManager> logger, IAmazonS3 s3Client, IConfiguration config)
+public class PhotosManager(ILogger<PhotosManager> logger, Lazy<IAmazonS3> s3Client, IConfiguration config)
 {
 
 
@@ -25,7 +25,7 @@ public class PhotosManager(ILogger<PhotosManager> logger, IAmazonS3 s3Client, IC
             UseChunkEncoding = false
         };
 
-        var response = await s3Client.PutObjectAsync(putRequest);
+        var response = await s3Client.Value.PutObjectAsync(putRequest);
 
         if (response.HttpStatusCode == HttpStatusCode.OK)
         {
@@ -51,7 +51,7 @@ public class PhotosManager(ILogger<PhotosManager> logger, IAmazonS3 s3Client, IC
         };
         try
         {
-            await s3Client.DeleteObjectAsync(deleteRequest);
+            await s3Client.Value.DeleteObjectAsync(deleteRequest);
         }
         catch (Exception ex)
         {
@@ -60,6 +60,16 @@ public class PhotosManager(ILogger<PhotosManager> logger, IAmazonS3 s3Client, IC
     }
     public string GetPhotoUrl(string photoUri)
     {
+        if (string.IsNullOrWhiteSpace(photoUri))
+        {
+            return string.Empty;
+        }
+
+        if (photoUri.StartsWith('/') || photoUri.StartsWith("http", StringComparison.OrdinalIgnoreCase))
+        {
+            return photoUri;
+        }
+
         var publicUrl = config["CF:PublicUrl"];
         return $"{publicUrl}/{photoUri}";
     }

--- a/Booker/Services/PhotosManager.cs
+++ b/Booker/Services/PhotosManager.cs
@@ -6,6 +6,14 @@ using System.Net;
 
 namespace Booker.Services;
 
+public sealed class PhotoStorageException : Exception
+{
+    public PhotoStorageException(string message, Exception? innerException = null)
+        : base(message, innerException)
+    {
+    }
+}
+
 public class PhotosManager(ILogger<PhotosManager> logger, Lazy<IAmazonS3> s3Client, IConfiguration config)
 {
 
@@ -13,6 +21,12 @@ public class PhotosManager(ILogger<PhotosManager> logger, Lazy<IAmazonS3> s3Clie
     public async Task<string> AddPhotoAsync(Stream stream, string fileExtension)
     {
         var bucketName = config["S3:BucketName"];
+
+        if (string.IsNullOrWhiteSpace(bucketName))
+        {
+            throw new PhotoStorageException(
+                "Przesyłanie zdjęć jest tymczasowo niedostępne. Spróbuj ponownie później.");
+        }
 
         var fileName = Guid.NewGuid().ToString() + fileExtension;
 
@@ -25,7 +39,23 @@ public class PhotosManager(ILogger<PhotosManager> logger, Lazy<IAmazonS3> s3Clie
             UseChunkEncoding = false
         };
 
-        var response = await s3Client.Value.PutObjectAsync(putRequest);
+        PutObjectResponse response;
+        try
+        {
+            response = await s3Client.Value.PutObjectAsync(putRequest);
+        }
+        catch (InvalidOperationException ex)
+        {
+            logger.LogError(ex, "Photo storage is not configured correctly.");
+            throw new PhotoStorageException(
+                "Przesyłanie zdjęć jest tymczasowo niedostępne. Spróbuj ponownie później.", ex);
+        }
+        catch (AmazonS3Exception ex)
+        {
+            logger.LogError(ex, "Photo upload to S3 failed.");
+            throw new PhotoStorageException(
+                "Nie można dodać zdjęcia. Spróbuj ponownie później albo skontaktuj się ze wsparciem.", ex);
+        }
 
         if (response.HttpStatusCode == HttpStatusCode.OK)
         {
@@ -34,7 +64,8 @@ public class PhotosManager(ILogger<PhotosManager> logger, Lazy<IAmazonS3> s3Clie
         else
         {
             logger.LogError("Failed to upload photo to S3. HTTP Status: {StatusCode}", response.HttpStatusCode);
-            throw new Exception("Nie można dodać zdjęcia. Spróbuj ponownie później albo skontaktuj się z wsparciem.");
+            throw new PhotoStorageException(
+                "Nie można dodać zdjęcia. Spróbuj ponownie później albo skontaktuj się ze wsparciem.");
         }
     }
 

--- a/Booker/Services/StartupUtilities.cs
+++ b/Booker/Services/StartupUtilities.cs
@@ -20,41 +20,42 @@ namespace Booker.Services
     {
         public static IServiceCollection AddBookerServices(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddSingleton(_ => new Lazy<IAmazonS3>(() =>
+            services.AddSingleton(serviceProvider =>
             {
                 var accessKey = configuration["S3:AccessKeyId"];
                 var secretKey = configuration["S3:SecretAccessKey"];
                 var serviceUrl = configuration["CF:ServiceUrl"];
                 var region = configuration["S3:Region"];
+                var logger = serviceProvider.GetRequiredService<ILogger<PhotosManager>>();
 
                 if (string.IsNullOrWhiteSpace(accessKey) || string.IsNullOrWhiteSpace(secretKey))
                 {
-                    throw new InvalidOperationException(
-                        "Przed przesłaniem zdjęć skonfiguruj S3:AccessKeyId i S3:SecretAccessKey.");
+                    logger.LogWarning("Photo uploads are disabled because S3 credentials are not configured.");
                 }
 
                 if (string.IsNullOrWhiteSpace(serviceUrl) && string.IsNullOrWhiteSpace(region))
                 {
-                    throw new InvalidOperationException(
-                        "Przed przesłaniem zdjęć skonfiguruj CF:ServiceUrl albo S3:Region.");
+                    logger.LogWarning("Photo uploads are disabled because neither CF:ServiceUrl nor S3:Region is configured.");
                 }
 
-                var clientConfiguration = new AmazonS3Config
+                return new Lazy<IAmazonS3>(() =>
                 {
-                    ForcePathStyle = true
-                };
+                    if (string.IsNullOrWhiteSpace(accessKey) || string.IsNullOrWhiteSpace(secretKey) ||
+                        (string.IsNullOrWhiteSpace(serviceUrl) && string.IsNullOrWhiteSpace(region)))
+                    {
+                        throw new InvalidOperationException("Photo storage is not configured.");
+                    }
 
-                if (!string.IsNullOrWhiteSpace(serviceUrl))
-                {
-                    clientConfiguration.ServiceURL = serviceUrl;
-                }
-                else
-                {
-                    clientConfiguration.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(region);
-                }
+                    var clientConfiguration = new AmazonS3Config { ForcePathStyle = true };
 
-                return new AmazonS3Client(accessKey, secretKey, clientConfiguration);
-            }));
+                    if (!string.IsNullOrWhiteSpace(serviceUrl))
+                        clientConfiguration.ServiceURL = serviceUrl;
+                    else
+                        clientConfiguration.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(region);
+
+                    return new AmazonS3Client(accessKey, secretKey, clientConfiguration);
+                });
+            });
 
             services.Configure<SmtpSettings>(configuration.GetSection("SmtpSettings"));
             services.AddTransient<SendMailSvc>();

--- a/Booker/Services/StartupUtilities.cs
+++ b/Booker/Services/StartupUtilities.cs
@@ -20,14 +20,41 @@ namespace Booker.Services
     {
         public static IServiceCollection AddBookerServices(this IServiceCollection services, IConfiguration configuration)
         {
-            services.AddSingleton<IAmazonS3>(x => new AmazonS3Client(
-                configuration["S3:AccessKeyId"], 
-                configuration["S3:SecretAccessKey"],
-                new AmazonS3Config
+            services.AddSingleton(_ => new Lazy<IAmazonS3>(() =>
+            {
+                var accessKey = configuration["S3:AccessKeyId"];
+                var secretKey = configuration["S3:SecretAccessKey"];
+                var serviceUrl = configuration["CF:ServiceUrl"];
+                var region = configuration["S3:Region"];
+
+                if (string.IsNullOrWhiteSpace(accessKey) || string.IsNullOrWhiteSpace(secretKey))
                 {
-                    ServiceURL = configuration["CF:ServiceUrl"],
+                    throw new InvalidOperationException(
+                        "Przed przesłaniem zdjęć skonfiguruj S3:AccessKeyId i S3:SecretAccessKey.");
+                }
+
+                if (string.IsNullOrWhiteSpace(serviceUrl) && string.IsNullOrWhiteSpace(region))
+                {
+                    throw new InvalidOperationException(
+                        "Przed przesłaniem zdjęć skonfiguruj CF:ServiceUrl albo S3:Region.");
+                }
+
+                var clientConfiguration = new AmazonS3Config
+                {
                     ForcePathStyle = true
-                }));
+                };
+
+                if (!string.IsNullOrWhiteSpace(serviceUrl))
+                {
+                    clientConfiguration.ServiceURL = serviceUrl;
+                }
+                else
+                {
+                    clientConfiguration.RegionEndpoint = Amazon.RegionEndpoint.GetBySystemName(region);
+                }
+
+                return new AmazonS3Client(accessKey, secretKey, clientConfiguration);
+            }));
 
             services.Configure<SmtpSettings>(configuration.GetSection("SmtpSettings"));
             services.AddTransient<SendMailSvc>();

--- a/Booker/wwwroot/img/icons.svg
+++ b/Booker/wwwroot/img/icons.svg
@@ -1,6 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" id="tabler-icons">
 	<defs>
-		<symbol id="tabler-adjustments-horizontal" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<symbol id="tabler-arrow-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<path d="M5 12l14 0" />
+		<path d="M13 18l6 -6" />
+		<path d="M13 6l6 6" />
+	</symbol>
+	<symbol id="tabler-book" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+		<path d="M3 19a9 9 0 0 1 9 0a9 9 0 0 1 9 0" />
+		<path d="M3 4a9 9 0 0 1 9 0a9 9 0 0 1 9 0" />
+		<path d="M3 4l0 15" />
+		<path d="M21 4l0 15" />
+		<path d="M12 4l0 15" />
+	</symbol>
+	<symbol id="tabler-adjustments-horizontal" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
 			<path d="M14 6m-2 0a2 2 0 1 0 4 0a2 2 0 1 0 -4 0" />
 			<path d="M4 6l8 0" />
 			<path d="M16 6l4 0" />

--- a/Booker/wwwroot/js/browse.js
+++ b/Booker/wwwroot/js/browse.js
@@ -1,0 +1,29 @@
+(() => {
+    function setFilter(name, value, enable) {
+        const element = document.querySelector(`[name="${name}"]`);
+        if (!element) return;
+
+        element.value = enable ? value : "";
+        element.form.requestSubmit();
+    }
+
+    htmx.onLoad(content => {
+        content.querySelectorAll("button.subject, button.grade, button.level").forEach(button => {
+            button.addEventListener("click", function () {
+                const name = this.classList.contains("subject")
+                    ? "subject"
+                    : this.classList.contains("grade") ? "grade" : "level";
+                const value = name === "grade"
+                    ? this.textContent.trim().slice(6, 7)
+                    : this.textContent.trim();
+
+                this.classList.toggle("outline");
+                setFilter(name, value, !this.classList.contains("outline"));
+            });
+        });
+    });
+
+    document.getElementById("mobileFilterSubmit")?.addEventListener("click", () => {
+        document.getElementById("filterDetails")?.removeAttribute("open");
+    });
+})();

--- a/Booker/wwwroot/scss/_hamburger.scss
+++ b/Booker/wwwroot/scss/_hamburger.scss
@@ -122,7 +122,28 @@
         align-items: center;
     }
 
+    nav[role="navigation"] > ul,
+    nav[role="navigation"] > [role="list"] {
+        display: flex;
+        align-items: center;
+        gap: 0.5rem;
+    }
+
     nav[role="navigation"] ul li {
+        display: flex;
+        align-items: center;
+    }
+
+    nav[role="navigation"] > [role="list"] li {
+        display: flex;
+        align-items: center;
+    }
+
+    nav[role="navigation"] > [role="list"] #login,
+    nav[role="navigation"] > [role="list"] #register {
+        margin-top: 0 !important;
+        margin-bottom: 0 !important;
+        align-self: stretch;
         display: flex;
         align-items: center;
     }
@@ -150,41 +171,71 @@ nav[role=navigation] > [role=list] {
 }
 
 @media (max-width: map.get(map.get(pico.$breakpoints, "md"), "viewport")) {
-    nav[role=navigation] {
-        position: sticky;
-        top: 0;
+    #{$parent-selector} nav[role="navigation"][data-breakpoint="md"] {
+        position: relative;
         background-color: var(--pico-background-color);
         border-bottom: 1px solid var(--pico-muted-border-color);
         box-shadow: var(--pico-card-box-shadow);
+        overflow: visible !important;
 
-        #hamburger-btn ~ [role=list] {
-            flex-direction: column-reverse;
+        #hamburger-btn ~ [role="list"] {
+            display: none;
+            flex-direction: column;
+            width: 100%;
+            position: absolute;
+            top: 100%;
+            left: 0;
+            right: 0;
             background-color: var(--pico-background-color);
-            transition: max-height var(#{$css-var-prefix}transition), opacity var(#{$css-var-prefix}transition), display var(#{$css-var-prefix}transition);
-            transition-behavior: allow-discrete;
+            z-index: 999;
+            padding: 1.25rem;
 
-            @starting-style {
-                max-height: 0;
-                opacity: 0;
+            > li {
+                width: 100%;
+                max-width: none;
+                margin-bottom: 0.75rem;
+            }
+
+            > li:last-child {
+                margin-bottom: 0;
+            }
+
+            #login {
+                display: block;
+                text-align: center;
+                padding: 0.6rem 1.5rem;
+                color: var(--pico-primary) !important;
+                border: var(--pico-border-width) solid var(--pico-primary);
+                border-radius: var(--pico-border-radius);
+                text-decoration: none;
+                font-size: 1rem;
+            }
+
+            #register {
+                display: block;
+                text-align: center;
+                padding: 0.75rem 1.5rem;
+                background-color: var(--pico-primary-background);
+                color: var(--pico-primary-inverse);
+                border-radius: var(--pico-border-radius);
+                font-size: 1rem;
+                text-decoration: none;
             }
 
             a {
                 &[role=button] {
                     display: block;
-                    margin: var(--pico-nav-element-spacing-vertical) var(--pico-nav-element-spacing-horizontal);
+                    width: 100%;
+                    box-sizing: border-box;
+                    padding: var(--pico-nav-element-spacing-vertical) var(--pico-nav-element-spacing-horizontal);
                 }
 
                 border-radius: var(--pico-border-radius);
-                border-block-end: 1px solid transparent;
                 transition: revert;
-
-                &:hover {
-                    border-bottom-color: transparent;
-                }
             }
         }
 
-        #hamburger-btn:checked ~ [role=list] {
+        #hamburger-btn:checked ~ [role="list"] {
             display: flex;
         }
 
@@ -210,10 +261,6 @@ nav[role=navigation] > [role=list] {
             a, button {
                 display: block;
                 padding: calc(var(--pico-form-element-spacing-vertical)) var(--pico-form-element-spacing-horizontal);
-            }
-
-            button {
-                //margin: calc(var(--pico-form-element-spacing-vertical) * 0.5) var(--pico-form-element-spacing-horizontal);
             }
         }
 

--- a/Booker/wwwroot/scss/_hamburger.scss
+++ b/Booker/wwwroot/scss/_hamburger.scss
@@ -116,6 +116,18 @@
 
 // Own code begins here
 
+/* Desktop: vertically center all nav items and their content */
+@media (min-width: map.get(map.get(pico.$breakpoints, "md"), "viewport") + 1px) {
+    #{$parent-selector} nav[role="navigation"] {
+        align-items: center;
+    }
+
+    nav[role="navigation"] ul li {
+        display: flex;
+        align-items: center;
+    }
+}
+
 #hamburger-btn ~ label {
     padding: var(--pico-nav-element-spacing-vertical) var(--pico-nav-element-spacing-horizontal);
     margin-right: calc(var(--pico-nav-element-spacing-horizontal) * -1);

--- a/Booker/wwwroot/scss/_hamburger.scss
+++ b/Booker/wwwroot/scss/_hamburger.scss
@@ -100,8 +100,6 @@
                 a:hover {
                     border-bottom-color: var(#{$css-var-prefix}underline);
                     text-decoration: none;
-                    //background-color: var(#{$css-var-prefix}primary-background) !important;
-                    //color: var(#{$css-var-prefix}primary-inverse);
                 }
             }
 
@@ -141,8 +139,7 @@
 
     nav[role="navigation"] > [role="list"] #login,
     nav[role="navigation"] > [role="list"] #register {
-        margin-top: 0 !important;
-        margin-bottom: 0 !important;
+        margin-block: 0;
         align-self: stretch;
         display: flex;
         align-items: center;
@@ -176,7 +173,7 @@ nav[role=navigation] > [role=list] {
         background-color: var(--pico-background-color);
         border-bottom: 1px solid var(--pico-muted-border-color);
         box-shadow: var(--pico-card-box-shadow);
-        overflow: visible !important;
+        overflow: visible;
 
         #hamburger-btn ~ [role="list"] {
             display: none;
@@ -204,7 +201,7 @@ nav[role=navigation] > [role=list] {
                 display: block;
                 text-align: center;
                 padding: 0.6rem 1.5rem;
-                color: var(--pico-primary) !important;
+                color: var(--pico-primary);
                 border: var(--pico-border-width) solid var(--pico-primary);
                 border-radius: var(--pico-border-radius);
                 text-decoration: none;

--- a/Booker/wwwroot/scss/_index.scss
+++ b/Booker/wwwroot/scss/_index.scss
@@ -150,6 +150,7 @@
         color: white;
         padding: 0.25em 0.5em;
         border-radius: 0.25em;
+        pointer-events: none;
     }
 }
 

--- a/Booker/wwwroot/scss/_index.scss
+++ b/Booker/wwwroot/scss/_index.scss
@@ -104,10 +104,12 @@
             grid-area: categories;
             align-content: end;
 
-            button {
+            button,
+            a[role="button"] {
                 font-size: 0.75em;
                 padding: 0 0.5em;
                 border-radius: 100vmax;
+                margin-bottom: 0;
             }
         }
 

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -50,7 +50,7 @@
 /* ===== Hero wall (diagonal scrolling books) ===== */
 .hero-wall {
     overflow: hidden;
-    height: 660px;
+    height: 520px;
     position: relative;
     border-radius: var(--pico-border-radius);
 
@@ -185,15 +185,28 @@
     }
 }
 
+.grid-gallery-single-row {
+    display: grid !important;
+    grid-template-columns: repeat(auto-fill, minmax(225px, 1fr));
+    gap: var(--pico-spacing);
+    overflow: hidden;
+
+    > article,
+    > [role="article"] {
+        margin-bottom: 0;
+    }
+}
+
 /* ===== Categories ===== */
 .category-badges {
     list-style: none;
     margin: 0;
     padding: 0;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: center;
     gap: 0.625rem;
+    overflow: hidden;
 }
 
 @keyframes categoryEnter {

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -75,7 +75,7 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 320%;
+    width: 400%;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
@@ -192,7 +192,8 @@
     padding: 0;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.5rem;
+    justify-content: center;
+    gap: 0.625rem;
 }
 
 @keyframes categoryEnter {
@@ -208,22 +209,23 @@
 }
 
 .category-tile {
+    list-style: none;
     animation: categoryEnter 0.3s ease-out backwards;
     animation-delay: calc(var(--i, 0) * 30ms);
 
     > a {
         display: inline-flex;
         align-items: center;
-        gap: 0.375rem;
+        gap: 0.5rem;
         margin-bottom: 0;
-        padding: 0.375rem 0.875rem;
-        font-size: 0.85rem;
+        padding: 0.5rem 1.125rem;
+        font-size: 0.95rem;
         line-height: 1.3;
         border-radius: 100vmax;
         text-wrap: nowrap;
 
         svg {
-            width: 1rem;
+            width: 1.125rem;
             height: auto;
             flex-shrink: 0;
         }

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -203,10 +203,9 @@
     margin: 0;
     padding: 0;
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     justify-content: center;
     gap: 0.625rem;
-    overflow: hidden;
 }
 
 @keyframes categoryEnter {

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -40,7 +40,6 @@
 }
 
 .hero-preview {
-    max-width: 320px;
     width: 100%;
 
     @media (max-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint") - 1) {
@@ -48,57 +47,81 @@
     }
 }
 
-/* ===== Hero carousel ===== */
-.hero-carousel {
+/* ===== Hero wall (diagonal scrolling books) ===== */
+.hero-wall {
     overflow: hidden;
-    border-radius: var(--pico-border-radius);
-    border: 1px solid var(--pico-card-border-color);
-    background-color: var(--pico-card-background-color);
-    height: 400px;
+    height: 480px;
     position: relative;
-    mask-image: linear-gradient(to bottom, transparent 0, black 12%, black 88%, transparent 100%);
-    -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 12%, black 88%, transparent 100%);
+    border-radius: var(--pico-border-radius);
+    mask-image: linear-gradient(105deg, transparent 0%, black 8%, black 92%, transparent 100%);
+    -webkit-mask-image: linear-gradient(105deg, transparent 0%, black 8%, black 92%, transparent 100%);
 }
 
-.hero-carousel-track {
-    list-style: none;
-    margin: 0;
-    padding: 0.75rem;
+.hero-wall-rotated {
+    position: absolute;
+    top: 50%;
+    left: 50%;
+    width: 280%;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
-    animation: heroScroll var(--carousel-duration, 20s) linear infinite;
+    transform: translate(-50%, -50%) rotate(-25deg);
 }
 
-@keyframes heroScroll {
-    0% {
-        transform: translateY(0);
+.hero-wall-row {
+    display: flex;
+    gap: 0.75rem;
+    width: max-content;
+    animation: wallScroll var(--row-duration, 40s) linear infinite;
+    pointer-events: none;
+
+    &:nth-child(1) {
+        --row-duration: 45s;
+        margin-left: -2rem;
     }
 
-    100% {
-        transform: translateY(-50%);
+    &:nth-child(2) {
+        --row-duration: 35s;
+        animation-direction: reverse;
+        margin-left: 2rem;
+    }
+
+    &:nth-child(3) {
+        --row-duration: 50s;
+        margin-left: -1rem;
     }
 }
 
-.hero-carousel:hover .hero-carousel-track {
+@keyframes wallScroll {
+    from {
+        transform: translateX(0);
+    }
+
+    to {
+        transform: translateX(-50%);
+    }
+}
+
+.hero-wall:hover .hero-wall-row {
     animation-play-state: paused;
 }
 
-.hero-book-card {
+.hero-book-tile {
+    flex-shrink: 0;
+    width: 160px;
     display: flex;
-    gap: 0.75rem;
-    align-items: center;
-    padding: 0.75rem;
-    border-radius: calc(var(--pico-border-radius) * 0.625);
-    background-color: var(--pico-secondary-background);
-    border: 1px solid var(--pico-muted-border-color);
-    pointer-events: none;
+    flex-direction: column;
+    gap: 0.375rem;
+    padding: 0.5rem;
+    border-radius: calc(var(--pico-border-radius) * 0.75);
+    background-color: var(--pico-card-background-color);
+    border: 1px solid var(--pico-card-border-color);
+    box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
 }
 
 .hero-book-cover {
-    flex-shrink: 0;
-    width: 48px;
-    height: 64px;
+    width: 100%;
+    aspect-ratio: 3 / 4;
     border-radius: 0.25rem;
     overflow: hidden;
     background-color: var(--pico-background-color);
@@ -118,13 +141,13 @@
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
-    min-width: 0;
+    padding: 0 0.25rem;
 }
 
 .hero-book-title {
-    font-size: 0.8125rem;
+    font-size: 0.75rem;
     font-weight: 600;
-    line-height: 1.3;
+    line-height: 1.25;
     overflow: hidden;
     display: -webkit-box;
     -webkit-line-clamp: 2;
@@ -133,7 +156,7 @@
 }
 
 .hero-book-price {
-    font-size: 0.875rem;
+    font-size: 0.8125rem;
     font-weight: 700;
     color: var(--pico-primary);
 }
@@ -226,7 +249,7 @@
         transform: none;
     }
 
-    .hero-carousel-track {
+    .hero-wall-row {
         animation: none;
     }
 }

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -10,7 +10,7 @@
     padding-block: clamp(1.5rem, 4vw, 3rem);
 
     @media (min-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint")) {
-        grid-template-columns: 1.1fr 0.9fr;
+        grid-template-columns: 1fr 1fr;
     }
 }
 
@@ -41,6 +41,8 @@
 
 .hero-preview {
     width: 100%;
+    position: relative;
+    overflow: hidden;
 
     @media (max-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint") - 1) {
         display: none;
@@ -50,15 +52,14 @@
 /* ===== Hero wall (diagonal scrolling books) ===== */
 .hero-wall {
     overflow: hidden;
-    height: 520px;
+    height: 560px;
     position: relative;
-    border-radius: var(--pico-border-radius);
 
-    /* Near-ellipse mask: books fade softly at all edges */
+    /* Mask clips to soft ellipse - this hides the vignette's hard edge */
     -webkit-mask-image:
-        radial-gradient(ellipse 75% 70% at center, black 30%, rgba(0, 0, 0, 0.6) 50%, transparent 72%);
+        radial-gradient(ellipse 120% 115% at center, black 40%, transparent 75%);
     mask-image:
-        radial-gradient(ellipse 75% 70% at center, black 30%, rgba(0, 0, 0, 0.6) 50%, transparent 72%);
+        radial-gradient(ellipse 120% 115% at center, black 40%, transparent 75%);
 
     &::after {
         content: "";
@@ -67,7 +68,7 @@
         z-index: 1;
         pointer-events: none;
         background:
-            radial-gradient(ellipse 60% 55% at center, transparent 45%, var(--pico-background-color) 80%);
+            radial-gradient(ellipse 65% 58% at center, transparent 20%, rgba(0, 0, 0, 0.1) 42%, var(--pico-background-color) 70%);
     }
 }
 
@@ -75,9 +76,12 @@
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 400%;
+    width: 600%;
+    height: 600%;
     display: flex;
     flex-direction: column;
+    justify-content: center;
+    align-items: center;
     gap: 0.75rem;
     transform: translate(-50%, -50%) rotate(-25deg);
 }
@@ -97,12 +101,20 @@
     &:nth-child(2) {
         --row-duration: 35s;
         animation-direction: reverse;
+        animation-delay: -17s;
         margin-left: 2rem;
     }
 
     &:nth-child(3) {
         --row-duration: 50s;
         margin-left: -1rem;
+    }
+
+    &:nth-child(4) {
+        --row-duration: 38s;
+        animation-direction: reverse;
+        animation-delay: -10s;
+        margin-left: 3rem;
     }
 }
 
@@ -194,6 +206,12 @@
     > article,
     > [role="article"] {
         margin-bottom: 0;
+    }
+
+    /* Mobile: 2 per row */
+    @media (max-width: map.get(map.get(pico.$breakpoints, "sm"), "breakpoint") - 1) {
+        grid-template-columns: repeat(2, 1fr);
+        gap: 0.625rem;
     }
 }
 

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -40,19 +40,102 @@
 }
 
 .hero-preview {
-    max-width: 280px;
-
-    [role="article"] {
-        margin-bottom: 0;
-    }
-
-    [role="article"] img {
-        max-height: 300px;
-    }
+    max-width: 320px;
+    width: 100%;
 
     @media (max-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint") - 1) {
         display: none;
     }
+}
+
+/* ===== Hero carousel ===== */
+.hero-carousel {
+    overflow: hidden;
+    border-radius: var(--pico-border-radius);
+    border: 1px solid var(--pico-card-border-color);
+    background-color: var(--pico-card-background-color);
+    height: 400px;
+    position: relative;
+    mask-image: linear-gradient(to bottom, transparent 0, black 12%, black 88%, transparent 100%);
+    -webkit-mask-image: linear-gradient(to bottom, transparent 0, black 12%, black 88%, transparent 100%);
+}
+
+.hero-carousel-track {
+    list-style: none;
+    margin: 0;
+    padding: 0.75rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.75rem;
+    animation: heroScroll var(--carousel-duration, 20s) linear infinite;
+}
+
+@keyframes heroScroll {
+    0% {
+        transform: translateY(0);
+    }
+
+    100% {
+        transform: translateY(-50%);
+    }
+}
+
+.hero-carousel:hover .hero-carousel-track {
+    animation-play-state: paused;
+}
+
+.hero-book-card {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.75rem;
+    border-radius: calc(var(--pico-border-radius) * 0.625);
+    background-color: var(--pico-secondary-background);
+    border: 1px solid var(--pico-muted-border-color);
+    pointer-events: none;
+}
+
+.hero-book-cover {
+    flex-shrink: 0;
+    width: 48px;
+    height: 64px;
+    border-radius: 0.25rem;
+    overflow: hidden;
+    background-color: var(--pico-background-color);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border: 1px solid var(--pico-muted-border-color);
+
+    img {
+        width: 100%;
+        height: 100%;
+        object-fit: contain;
+    }
+}
+
+.hero-book-info {
+    display: flex;
+    flex-direction: column;
+    gap: 0.125rem;
+    min-width: 0;
+}
+
+.hero-book-title {
+    font-size: 0.8125rem;
+    font-weight: 600;
+    line-height: 1.3;
+    overflow: hidden;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+}
+
+.hero-book-price {
+    font-size: 0.875rem;
+    font-weight: 700;
+    color: var(--pico-primary);
 }
 
 /* ===== Sections ===== */
@@ -90,14 +173,16 @@
 .category-tile {
     animation: categoryEnter 0.3s ease-out backwards;
     animation-delay: calc(var(--i, 0) * 30ms);
+    display: flex;
 
     > a {
         width: 100%;
+        height: 100%;
         display: inline-flex;
         align-items: center;
         justify-content: center;
         gap: 0.5rem;
-        min-height: 3rem;
+        min-height: 3.5rem;
         text-wrap: balance;
         text-align: center;
         font-size: 0.95rem;
@@ -139,6 +224,10 @@
 
     .category-tile > a:active {
         transform: none;
+    }
+
+    .hero-carousel-track {
+        animation: none;
     }
 }
 

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -222,6 +222,40 @@
     }
 }
 
+/* Give ultra-wide displays more useful density without stretching the page edge to edge. */
+@media (min-width: 1920px) {
+    main.container.landing-page {
+        max-width: min(1800px, calc(100% - 6rem));
+    }
+
+    .landing-hero {
+        grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
+        gap: clamp(3rem, 5vw, 6rem);
+    }
+
+    .hero-content {
+        h1 {
+            --pico-font-size: clamp(2.25rem, 1.25vw, 2.75rem);
+        }
+
+        p {
+            font-size: 1.25rem;
+        }
+    }
+
+    .hero-wall {
+        height: 640px;
+    }
+
+    .grid-gallery-single-row {
+        grid-template-columns: repeat(5, minmax(0, 1fr));
+
+        > :nth-child(5) {
+            display: flex;
+        }
+    }
+}
+
 /* ===== Categories ===== */
 .category-badges {
     list-style: none;

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -40,12 +40,15 @@
 }
 
 .hero-preview {
+    max-width: 280px;
+
     [role="article"] {
         margin-bottom: 0;
     }
 
-    /* Visually de-emphasize - decorative only */
-    opacity: 0.9;
+    [role="article"] img {
+        max-height: 300px;
+    }
 
     @media (max-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint") - 1) {
         display: none;

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -203,9 +203,10 @@
     margin: 0;
     padding: 0;
     display: flex;
-    flex-wrap: wrap;
+    flex-wrap: nowrap;
     justify-content: center;
     gap: 0.625rem;
+    overflow: hidden;
 }
 
 @keyframes categoryEnter {

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -50,18 +50,32 @@
 /* ===== Hero wall (diagonal scrolling books) ===== */
 .hero-wall {
     overflow: hidden;
-    height: 480px;
+    height: 560px;
     position: relative;
     border-radius: var(--pico-border-radius);
-    mask-image: linear-gradient(105deg, transparent 0%, black 8%, black 92%, transparent 100%);
-    -webkit-mask-image: linear-gradient(105deg, transparent 0%, black 8%, black 92%, transparent 100%);
+
+    /* Multi-layer radial vignette + soft fog so books appear to emerge from air */
+    -webkit-mask-image:
+        radial-gradient(ellipse 85% 80% at center, black 35%, rgba(0, 0, 0, 0.75) 55%, transparent 85%);
+    mask-image:
+        radial-gradient(ellipse 85% 80% at center, black 35%, rgba(0, 0, 0, 0.75) 55%, transparent 85%);
+
+    &::after {
+        content: "";
+        position: absolute;
+        inset: 0;
+        z-index: 1;
+        pointer-events: none;
+        background:
+            radial-gradient(ellipse 70% 65% at center, transparent 40%, var(--pico-background-color) 90%);
+    }
 }
 
 .hero-wall-rotated {
     position: absolute;
     top: 50%;
     left: 50%;
-    width: 280%;
+    width: 320%;
     display: flex;
     flex-direction: column;
     gap: 0.75rem;
@@ -108,7 +122,7 @@
 
 .hero-book-tile {
     flex-shrink: 0;
-    width: 160px;
+    width: 185px;
     display: flex;
     flex-direction: column;
     gap: 0.375rem;

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -42,34 +42,23 @@
 .hero-preview {
     width: 100%;
     position: relative;
-    overflow: hidden;
+    overflow: visible;
+    isolation: isolate;
 
     @media (max-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint") - 1) {
         display: none;
     }
 }
 
-/* ===== Hero wall (diagonal scrolling books) ===== */
+/* ===== Hero wall (three independent book streams) ===== */
 .hero-wall {
-    overflow: hidden;
+    width: 100%;
     height: 560px;
     position: relative;
-
-    /* Mask clips to soft ellipse - this hides the vignette's hard edge */
-    -webkit-mask-image:
-        radial-gradient(ellipse 120% 115% at center, black 40%, transparent 75%);
-    mask-image:
-        radial-gradient(ellipse 120% 115% at center, black 40%, transparent 75%);
-
-    &::after {
-        content: "";
-        position: absolute;
-        inset: 0;
-        z-index: 1;
-        pointer-events: none;
-        background:
-            radial-gradient(ellipse 65% 58% at center, transparent 20%, rgba(0, 0, 0, 0.1) 42%, var(--pico-background-color) 70%);
-    }
+    margin-inline: auto;
+    overflow: hidden;
+    -webkit-mask-image: radial-gradient(ellipse 120% 115% at center, black 24%, transparent 43%);
+    mask-image: radial-gradient(ellipse 120% 115% at center, black 24%, transparent 43%);
 }
 
 .hero-wall-rotated {
@@ -82,59 +71,53 @@
     flex-direction: column;
     justify-content: center;
     align-items: center;
-    gap: 0.75rem;
-    transform: translate(-50%, -50%) rotate(-25deg);
+    gap: 0.9rem;
+    transform: translate(-50%, -50%) rotate(-22deg);
 }
 
 .hero-wall-row {
-    display: flex;
-    gap: 0.75rem;
     width: max-content;
-    animation: wallScroll var(--row-duration, 40s) linear infinite;
-    pointer-events: none;
 
     &:nth-child(1) {
-        --row-duration: 45s;
-        margin-left: -2rem;
+        margin-left: -4rem;
     }
 
     &:nth-child(2) {
-        --row-duration: 35s;
-        animation-direction: reverse;
-        animation-delay: -17s;
-        margin-left: 2rem;
+        margin-left: 7rem;
+
+        .hero-wall-track {
+            --stream-duration: 31s;
+            animation-direction: reverse;
+        }
     }
 
     &:nth-child(3) {
-        --row-duration: 50s;
-        margin-left: -1rem;
-    }
+        margin-left: -2rem;
 
-    &:nth-child(4) {
-        --row-duration: 38s;
-        animation-direction: reverse;
-        animation-delay: -10s;
-        margin-left: 3rem;
+        .hero-wall-track {
+            --stream-duration: 37s;
+        }
     }
 }
 
-@keyframes wallScroll {
-    from {
-        transform: translateX(0);
-    }
-
-    to {
-        transform: translateX(-50%);
-    }
+.hero-wall-track {
+    --stream-duration: 34s;
+    display: flex;
+    width: max-content;
+    animation: streamBooks var(--stream-duration) linear infinite;
+    will-change: transform;
 }
 
-.hero-wall:hover .hero-wall-row {
-    animation-play-state: paused;
+.hero-wall-sequence {
+    display: flex;
+    flex-shrink: 0;
+    gap: 0.9rem;
+    padding-right: 0.9rem;
 }
 
 .hero-book-tile {
+    width: clamp(158px, 13vw, 185px);
     flex-shrink: 0;
-    width: 185px;
     display: flex;
     flex-direction: column;
     gap: 0.375rem;
@@ -143,6 +126,17 @@
     background-color: var(--pico-card-background-color);
     border: 1px solid var(--pico-card-border-color);
     box-shadow: 0 2px 6px rgba(0, 0, 0, 0.08);
+    pointer-events: none;
+}
+
+@keyframes streamBooks {
+    from {
+        transform: translateX(0);
+    }
+
+    to {
+        transform: translateX(-25%);
+    }
 }
 
 .hero-book-cover {
@@ -160,6 +154,8 @@
         width: 100%;
         height: 100%;
         object-fit: contain;
+        outline: 1px solid rgba(0, 0, 0, 0.1);
+        outline-offset: -1px;
     }
 }
 
@@ -167,7 +163,8 @@
     display: flex;
     flex-direction: column;
     gap: 0.125rem;
-    padding: 0 0.25rem;
+    min-width: 0;
+    padding-inline: 0.2rem;
 }
 
 .hero-book-title {
@@ -185,6 +182,13 @@
     font-size: 0.8125rem;
     font-weight: 700;
     color: var(--pico-primary);
+    font-variant-numeric: tabular-nums;
+}
+
+@media (prefers-color-scheme: dark) {
+    .hero-book-cover img {
+        outline-color: rgba(255, 255, 255, 0.1);
+    }
 }
 
 /* ===== Sections ===== */
@@ -294,8 +298,9 @@
         transform: none;
     }
 
-    .hero-wall-row {
+    .hero-wall-track {
         animation: none;
+        transform: translateX(-12%);
     }
 }
 

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -50,15 +50,15 @@
 /* ===== Hero wall (diagonal scrolling books) ===== */
 .hero-wall {
     overflow: hidden;
-    height: 560px;
+    height: 660px;
     position: relative;
     border-radius: var(--pico-border-radius);
 
-    /* Multi-layer radial vignette + soft fog so books appear to emerge from air */
+    /* Near-ellipse mask: books fade softly at all edges */
     -webkit-mask-image:
-        radial-gradient(ellipse 85% 80% at center, black 35%, rgba(0, 0, 0, 0.75) 55%, transparent 85%);
+        radial-gradient(ellipse 75% 70% at center, black 30%, rgba(0, 0, 0, 0.6) 50%, transparent 72%);
     mask-image:
-        radial-gradient(ellipse 85% 80% at center, black 35%, rgba(0, 0, 0, 0.75) 55%, transparent 85%);
+        radial-gradient(ellipse 75% 70% at center, black 30%, rgba(0, 0, 0, 0.6) 50%, transparent 72%);
 
     &::after {
         content: "";
@@ -67,7 +67,7 @@
         z-index: 1;
         pointer-events: none;
         background:
-            radial-gradient(ellipse 70% 65% at center, transparent 40%, var(--pico-background-color) 90%);
+            radial-gradient(ellipse 60% 55% at center, transparent 45%, var(--pico-background-color) 80%);
     }
 }
 
@@ -186,13 +186,13 @@
 }
 
 /* ===== Categories ===== */
-.category-grid {
+.category-badges {
     list-style: none;
     margin: 0;
     padding: 0;
-    display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
-    gap: var(--pico-spacing);
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
 }
 
 @keyframes categoryEnter {
@@ -210,22 +210,20 @@
 .category-tile {
     animation: categoryEnter 0.3s ease-out backwards;
     animation-delay: calc(var(--i, 0) * 30ms);
-    display: flex;
 
     > a {
-        width: 100%;
-        height: 100%;
         display: inline-flex;
         align-items: center;
-        justify-content: center;
-        gap: 0.5rem;
-        min-height: 3.5rem;
-        text-wrap: balance;
-        text-align: center;
-        font-size: 0.95rem;
+        gap: 0.375rem;
+        margin-bottom: 0;
+        padding: 0.375rem 0.875rem;
+        font-size: 0.85rem;
+        line-height: 1.3;
+        border-radius: 100vmax;
+        text-wrap: nowrap;
 
         svg {
-            width: 1.125rem;
+            width: 1rem;
             height: auto;
             flex-shrink: 0;
         }

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -138,3 +138,62 @@
         transform: none;
     }
 }
+
+/* ===== Footer ===== */
+footer[role="contentinfo"] {
+    margin-top: 3rem;
+    padding-block: 1.5rem;
+    background-color: var(--pico-card-background-color);
+    border-top: 1px solid var(--pico-card-border-color);
+}
+
+.footer-content {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+
+    nav ul {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 1.5rem;
+        margin: 0;
+        padding: 0;
+        list-style: none;
+
+        a {
+            color: var(--pico-muted-color);
+            text-decoration: none;
+            font-size: 0.875rem;
+
+            &:hover {
+                color: var(--pico-primary);
+                text-decoration: underline;
+            }
+        }
+
+        .footer-help-link {
+            background: none;
+            border: none;
+            padding: 0;
+            color: var(--pico-muted-color);
+            font-size: 0.875rem;
+            cursor: pointer;
+
+            &:hover {
+                color: var(--pico-primary);
+                text-decoration: underline;
+            }
+        }
+    }
+
+    @media (max-width: map.get(map.get(pico.$breakpoints, "sm"), "breakpoint") - 1) {
+        flex-direction: column;
+        align-items: flex-start;
+
+        nav ul {
+            gap: 1rem;
+        }
+    }
+}

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -1,0 +1,140 @@
+@use "pico";
+@use "utils";
+@use "sass:map";
+
+/* ===== Hero ===== */
+.landing-hero {
+    display: grid;
+    gap: 2rem;
+    align-items: center;
+    padding-block: clamp(1.5rem, 4vw, 3rem);
+
+    @media (min-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint")) {
+        grid-template-columns: 1.1fr 0.9fr;
+    }
+}
+
+.hero-content {
+    h1 {
+        @include utils.h1-size;
+        --pico-font-weight: 800;
+        letter-spacing: -0.02em;
+        margin-bottom: 0.5rem;
+    }
+
+    p {
+        font-size: 1.125rem;
+        line-height: 1.5;
+        margin-bottom: 1.5rem;
+    }
+}
+
+.hero-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+
+    a[role="button"] {
+        margin-bottom: 0;
+    }
+}
+
+.hero-preview {
+    [role="article"] {
+        margin-bottom: 0;
+    }
+
+    /* Visually de-emphasize - decorative only */
+    opacity: 0.9;
+
+    @media (max-width: map.get(map.get(pico.$breakpoints, "lg"), "breakpoint") - 1) {
+        display: none;
+    }
+}
+
+/* ===== Sections ===== */
+.landing-section {
+    padding-block: clamp(1.5rem, 3vw, 2.5rem);
+
+    h2 {
+        @include utils.h3-size;
+        margin-bottom: 1.25rem;
+    }
+}
+
+/* ===== Categories ===== */
+.category-grid {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+    gap: var(--pico-spacing);
+}
+
+@keyframes categoryEnter {
+    0% {
+        opacity: 0;
+        transform: translateY(0.5rem);
+    }
+
+    100% {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.category-tile {
+    animation: categoryEnter 0.3s ease-out backwards;
+    animation-delay: calc(var(--i, 0) * 30ms);
+
+    > a {
+        width: 100%;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        gap: 0.5rem;
+        min-height: 3rem;
+        text-wrap: balance;
+        text-align: center;
+        font-size: 0.95rem;
+
+        svg {
+            width: 1.125rem;
+            height: auto;
+            flex-shrink: 0;
+        }
+
+        &:active {
+            transform: scale(0.96);
+        }
+    }
+}
+
+.see-all-categories {
+    text-align: center;
+    margin-top: 1.5rem;
+
+    a {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.25rem;
+        color: var(--pico-primary);
+        text-decoration: none;
+        font-weight: 600;
+
+        &:hover {
+            text-decoration: underline;
+        }
+    }
+}
+
+@media (prefers-reduced-motion: reduce) {
+    .category-tile {
+        animation: none;
+    }
+
+    .category-tile > a:active {
+        transform: none;
+    }
+}

--- a/Booker/wwwroot/scss/_landing.scss
+++ b/Booker/wwwroot/scss/_landing.scss
@@ -202,14 +202,17 @@
 }
 
 .grid-gallery-single-row {
-    display: grid !important;
-    grid-template-columns: repeat(auto-fill, minmax(225px, 1fr));
+    grid-template-columns: repeat(4, minmax(0, 1fr));
     gap: var(--pico-spacing);
     overflow: hidden;
 
     > article,
     > [role="article"] {
         margin-bottom: 0;
+    }
+
+    > :nth-child(n + 5) {
+        display: none;
     }
 
     /* Mobile: 2 per row */
@@ -225,10 +228,9 @@
     margin: 0;
     padding: 0;
     display: flex;
-    flex-wrap: nowrap;
+    flex-wrap: wrap;
     justify-content: center;
     gap: 0.625rem;
-    overflow: hidden;
 }
 
 @keyframes categoryEnter {

--- a/Booker/wwwroot/scss/_utils.scss
+++ b/Booker/wwwroot/scss/_utils.scss
@@ -21,6 +21,8 @@
 
         &:focus-visible {
             box-shadow: none;
+            text-decoration-thickness: 2px;
+            text-underline-offset: 2px;
         }
     }
 }

--- a/Booker/wwwroot/scss/site.scss
+++ b/Booker/wwwroot/scss/site.scss
@@ -2,6 +2,7 @@
 
 @use "pico"  with ( $theme-color: "azure" );
 @use "index";
+@use "landing";
 @use "book";
 @use "add";
 @use "identity";


### PR DESCRIPTION
Closes #27

My proposal for the landing page redesign!

## Changes
- Redesigned landing page (Index) with hero section featuring animated book carousel, popular subjects category tiles, and recent listings
- Extracted browsing UI into dedicated Browse page (Browse.cshtml / Browse.cshtml.cs) with filters and htmx-driven search
- Added footer with logo, privacy link, and help center across all pages (_Layout)
- Deferred S3 client creation via Lazy<IAmazonS3> so the app boots without S3 credentials configured
- Hardened PhotosManager.GetPhotoUrl against empty/absolute/root-relative URIs
- Added tabler-book and tabler-arrow-right icon symbols
- Reordered login/register nav items in _LoginPartial

Screenshots: 
<img width="450" height="922" alt="Zrzut ekranu 2026-06-29 181543" src="https://github.com/user-attachments/assets/128e3a67-6ca2-4e31-8836-de98a74735b2" />
<img width="2545" height="1439" alt="Zrzut ekranu 2026-06-29 181523" src="https://github.com/user-attachments/assets/514d23b8-8132-4ddd-bcac-740dc9a365ac" />
<img width="2534" height="1439" alt="Zrzut ekranu 2026-06-29 181530" src="https://github.com/user-attachments/assets/d1e8312c-bdc7-4a0c-abe8-eec6bb9b2a4d" />
