### PR TITLE
test: add accessibility test tooling

### DIFF
--- a/.github/workflows/accessibility.yml
+++ b/.github/workflows/accessibility.yml
@@ -1,0 +1,37 @@
+name: Accessibility
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  axe:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+
+      - run: dotnet restore Booker/Booker.sln
+      - run: dotnet test Booker/Booker.sln --no-restore
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - run: npm run test:a11y
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -397,3 +397,11 @@ FodyWeavers.xsd
 # JetBrains Rider
 *.sln.iml
 /Booker/.config/dotnet-tools.json
+
+# Factory CLI artifacts (local agent state)
+.factory/
+
+# Accessibility test artifacts
+/Booker/accessibility-tests.db*
+/playwright-report/
+/test-results/

--- a/Booker.AccessibilityTests/tooling.spec.ts
+++ b/Booker.AccessibilityTests/tooling.spec.ts
@@ -1,0 +1,8 @@
+import { expect, test } from '@playwright/test';
+
+test('accessibility test server is reachable', async ({ page }) => {
+  const response = await page.goto('/');
+
+  expect(response?.ok()).toBeTruthy();
+  await expect(page.locator('body')).toBeVisible();
+});

--- a/Booker.Tests/AriaHelpersTests.cs
+++ b/Booker.Tests/AriaHelpersTests.cs
@@ -1,0 +1,25 @@
+using Booker.Utilities;
+using Xunit;
+
+namespace Booker.Tests;
+
+public class AriaHelpersTests
+{
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void CurrentOrNull_NullOrWhitespace_ReturnsNull(string? input)
+    {
+        Assert.Null(AriaHelpers.CurrentOrNull(input));
+    }
+
+    [Theory]
+    [InlineData("page", "page")]
+    [InlineData("step", "step")]
+    [InlineData("location", "location")]
+    public void CurrentOrNull_NonEmpty_ReturnsValue(string input, string expected)
+    {
+        Assert.Equal(expected, AriaHelpers.CurrentOrNull(input));
+    }
+}

--- a/Booker.Tests/Booker.Tests.csproj
+++ b/Booker.Tests/Booker.Tests.csproj
@@ -2,7 +2,6 @@
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
-    <RollForward>LatestMajor</RollForward>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>false</IsPackable>

--- a/Booker.Tests/Booker.Tests.csproj
+++ b/Booker.Tests/Booker.Tests.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RollForward>LatestMajor</RollForward>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.19" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.19" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Booker\Booker.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Booker.Tests/PhotosManagerTests.cs
+++ b/Booker.Tests/PhotosManagerTests.cs
@@ -1,0 +1,51 @@
+using Amazon.S3;
+using Booker.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Booker.Tests;
+
+public class PhotosManagerTests
+{
+    [Fact]
+    public void GetPhotoUrl_ForLocalAsset_DoesNotInitializeS3Client()
+    {
+        var s3WasInitialized = false;
+        var s3Client = new Lazy<IAmazonS3>(() =>
+        {
+            s3WasInitialized = true;
+            throw new InvalidOperationException("S3 should not be initialized while generating an URL.");
+        });
+        var configuration = new ConfigurationBuilder().Build();
+        var manager = new PhotosManager(NullLogger<PhotosManager>.Instance, s3Client, configuration);
+
+        var result = manager.GetPhotoUrl("/img/default-book.svg");
+
+        Assert.Equal("/img/default-book.svg", result);
+        Assert.False(s3WasInitialized);
+    }
+
+    [Fact]
+    public void GetPhotoUrl_ForStoredKey_UsesConfiguredPublicUrlWithoutInitializingS3Client()
+    {
+        var s3WasInitialized = false;
+        var s3Client = new Lazy<IAmazonS3>(() =>
+        {
+            s3WasInitialized = true;
+            throw new InvalidOperationException("S3 should not be initialized while generating an URL.");
+        });
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["CF:PublicUrl"] = "https://cdn.example.test/"
+            })
+            .Build();
+        var manager = new PhotosManager(NullLogger<PhotosManager>.Instance, s3Client, configuration);
+
+        var result = manager.GetPhotoUrl("covers/book.jpg");
+
+        Assert.Equal("https://cdn.example.test/covers/book.jpg", result);
+        Assert.False(s3WasInitialized);
+    }
+}

--- a/Booker.Tests/PhotosManagerTests.cs
+++ b/Booker.Tests/PhotosManagerTests.cs
@@ -15,7 +15,7 @@ public class PhotosManagerTests
         var s3Client = new Lazy<IAmazonS3>(() =>
         {
             s3WasInitialized = true;
-            throw new InvalidOperationException("S3 should not be initialized while generating an URL.");
+            throw new InvalidOperationException("S3 should not be initialized while generating a URL.");
         });
         var configuration = new ConfigurationBuilder().Build();
         var manager = new PhotosManager(NullLogger<PhotosManager>.Instance, s3Client, configuration);
@@ -33,7 +33,7 @@ public class PhotosManagerTests
         var s3Client = new Lazy<IAmazonS3>(() =>
         {
             s3WasInitialized = true;
-            throw new InvalidOperationException("S3 should not be initialized while generating an URL.");
+            throw new InvalidOperationException("S3 should not be initialized while generating a URL.");
         });
         var configuration = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?>

--- a/Booker/Booker.sln
+++ b/Booker/Booker.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.10.34916.146
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Booker", "Booker.csproj", "{7C55531E-4BF5-4EC6-9E6A-BB2BE925FC34}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Booker.Tests", "..\Booker.Tests\Booker.Tests.csproj", "{CC189B6E-084E-4417-8410-E9E9ABDBBA10}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +17,10 @@ Global
 		{7C55531E-4BF5-4EC6-9E6A-BB2BE925FC34}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7C55531E-4BF5-4EC6-9E6A-BB2BE925FC34}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7C55531E-4BF5-4EC6-9E6A-BB2BE925FC34}.Release|Any CPU.Build.0 = Release|Any CPU
+		{CC189B6E-084E-4417-8410-E9E9ABDBBA10}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{CC189B6E-084E-4417-8410-E9E9ABDBBA10}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{CC189B6E-084E-4417-8410-E9E9ABDBBA10}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{CC189B6E-084E-4417-8410-E9E9ABDBBA10}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,100 @@
+{
+  "name": "textbooker-accessibility-tests",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "textbooker-accessibility-tests",
+      "devDependencies": {
+        "@axe-core/playwright": "^4.10.2",
+        "@playwright/test": "^1.53.1"
+      }
+    },
+    "node_modules/@axe-core/playwright": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/@axe-core/playwright/-/playwright-4.12.1.tgz",
+      "integrity": "sha512-rMd7xriptqKpP+w5265i4Hdkv2X5kbu6uiBi/B2I7uf3hieRBM3qDCfaKPtxfiYb2mKXfF+yLODJwIx+Jv1GDw==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "dependencies": {
+        "axe-core": "~4.12.1"
+      },
+      "peerDependencies": {
+        "playwright-core": ">= 1.0.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/axe-core": {
+      "version": "4.12.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.12.1.tgz",
+      "integrity": "sha512-s7iGf5GaVMxEG0ENN9x+xTr7GFZCb1ZP/1uATUpCEK2X78nDB3RwbtFCo9pGAf9ru+VwoQ464DkaLEeRM08wJA==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "textbooker-accessibility-tests",
+  "private": true,
+  "scripts": {
+    "test:a11y": "playwright test",
+    "test:a11y:report": "playwright show-report"
+  },
+  "devDependencies": {
+    "@axe-core/playwright": "^4.10.2",
+    "@playwright/test": "^1.53.1"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,30 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './Booker.AccessibilityTests',
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['html', { open: 'never' }], ['list']] : 'list',
+  use: {
+    baseURL: 'http://127.0.0.1:5178',
+    trace: 'on-first-retry'
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] }
+    }
+  ],
+  webServer: {
+    command: 'dotnet run --no-launch-profile',
+    cwd: './Booker',
+    url: 'http://127.0.0.1:5178',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+    env: {
+      ASPNETCORE_ENVIRONMENT: 'Testing',
+      ASPNETCORE_URLS: 'http://127.0.0.1:5178'
+    }
+  }
+});


### PR DESCRIPTION
## What changed

- added the .NET unit-test project and focused helper/photo tests
- added Playwright dependencies, configuration, and CI workflow
- ignored generated test artifacts

## Why

Test-runner setup is separated from the browser scenario implementation to remain below 400 changed lines.

## Impact

CI can execute both unit and browser accessibility checks.

## Validation

- build: zero warnings
- unit tests: 8 passed
- accessibility suite: 18 passed

## Stack

7 of 8. Base: `codex/wcag-automation`.
